### PR TITLE
fix: update `Applicant` definition

### DIFF
--- a/examples/data/ldcE.ts
+++ b/examples/data/ldcE.ts
@@ -35,16 +35,13 @@ export const validLDCE: Schema = {
     },
     applicant: {
       type: 'individual',
-      contact: {
-        name: {
-          first: 'Roald',
-          last: 'Dahl',
-        },
-        email: 'f.fox@boggischickenshed.com',
-        phone: {
-          primary: 'Not provided by agent',
-        },
-        company: {},
+      name: {
+        first: 'Roald',
+        last: 'Dahl',
+      },
+      email: 'f.fox@boggischickenshed.com',
+      phone: {
+        primary: 'Not provided by agent',
       },
       address: {
         sameAsSiteAddress: true,
@@ -72,16 +69,13 @@ export const validLDCE: Schema = {
         ],
       },
       agent: {
-        contact: {
-          name: {
-            first: 'F',
-            last: 'Fox',
-          },
-          email: 'f.fox@boggischickenshed.com',
-          phone: {
-            primary: '0234 567 8910',
-          },
-          company: {},
+        name: {
+          first: 'F',
+          last: 'Fox',
+        },
+        email: 'f.fox@boggischickenshed.com',
+        phone: {
+          primary: '0234 567 8910',
         },
         address: {
           line1: 'The Tree',

--- a/examples/data/ldcP.ts
+++ b/examples/data/ldcP.ts
@@ -32,16 +32,13 @@ export const validLDCP: Schema = {
     },
     applicant: {
       type: 'individual',
-      contact: {
-        name: {
-          first: 'Enid',
-          last: 'Blyton',
-        },
-        email: 'famousfive@example.com',
-        phone: {
-          primary: '05555 555 555',
-        },
-        company: {},
+      name: {
+        first: 'Enid',
+        last: 'Blyton',
+      },
+      email: 'famousfive@example.com',
+      phone: {
+        primary: '05555 555 555',
       },
       address: {
         sameAsSiteAddress: true,

--- a/examples/data/planningPermission.ts
+++ b/examples/data/planningPermission.ts
@@ -35,16 +35,13 @@ export const validPlanningPermission: Schema = {
     },
     applicant: {
       type: 'individual',
-      contact: {
-        name: {
-          first: 'David',
-          last: 'Bowie',
-        },
-        email: 'ziggy@example.com',
-        phone: {
-          primary: 'Not provided by agent',
-        },
-        company: {},
+      name: {
+        first: 'David',
+        last: 'Bowie',
+      },
+      email: 'ziggy@example.com',
+      phone: {
+        primary: 'Not provided by agent',
       },
       address: {
         sameAsSiteAddress: true,
@@ -57,16 +54,13 @@ export const validPlanningPermission: Schema = {
         certificate: 'a',
       },
       agent: {
-        contact: {
-          name: {
-            first: 'Ziggy',
-            last: 'Stardust',
-          },
-          email: 'ziggy@example.com',
-          phone: {
-            primary: '01100 0110 0011',
-          },
-          company: {},
+        name: {
+          first: 'Ziggy',
+          last: 'Stardust',
+        },
+        email: 'ziggy@example.com',
+        phone: {
+          primary: '01100 0110 0011',
         },
         address: {
           line1: '40 Stansfield Road',

--- a/examples/data/priorApproval.ts
+++ b/examples/data/priorApproval.ts
@@ -37,18 +37,16 @@ export const validPriorApproval: Schema = {
     },
     applicant: {
       type: 'company',
-      contact: {
-        name: {
-          first: 'William',
-          last: 'Shakespeare',
-        },
-        email: 'thebard@example.com',
-        phone: {
-          primary: '2830407283',
-        },
-        company: {
-          name: "Lord Chamberlain's Men",
-        },
+      name: {
+        first: 'William',
+        last: 'Shakespeare',
+      },
+      email: 'thebard@example.com',
+      phone: {
+        primary: '2830407283',
+      },
+      company: {
+        name: "Lord Chamberlain's Men",
       },
       address: {
         sameAsSiteAddress: true,

--- a/examples/validLawfulDevelopmentCertificateExisting.json
+++ b/examples/validLawfulDevelopmentCertificateExisting.json
@@ -33,16 +33,13 @@
     },
     "applicant": {
       "type": "individual",
-      "contact": {
-        "name": {
-          "first": "Roald",
-          "last": "Dahl"
-        },
-        "email": "f.fox@boggischickenshed.com",
-        "phone": {
-          "primary": "Not provided by agent"
-        },
-        "company": {}
+      "name": {
+        "first": "Roald",
+        "last": "Dahl"
+      },
+      "email": "f.fox@boggischickenshed.com",
+      "phone": {
+        "primary": "Not provided by agent"
       },
       "address": {
         "sameAsSiteAddress": true
@@ -70,16 +67,13 @@
         ]
       },
       "agent": {
-        "contact": {
-          "name": {
-            "first": "F",
-            "last": "Fox"
-          },
-          "email": "f.fox@boggischickenshed.com",
-          "phone": {
-            "primary": "0234 567 8910"
-          },
-          "company": {}
+        "name": {
+          "first": "F",
+          "last": "Fox"
+        },
+        "email": "f.fox@boggischickenshed.com",
+        "phone": {
+          "primary": "0234 567 8910"
         },
         "address": {
           "line1": "The Tree",

--- a/examples/validLawfulDevelopmentCertificateProposed.json
+++ b/examples/validLawfulDevelopmentCertificateProposed.json
@@ -30,16 +30,13 @@
     },
     "applicant": {
       "type": "individual",
-      "contact": {
-        "name": {
-          "first": "Enid",
-          "last": "Blyton"
-        },
-        "email": "famousfive@example.com",
-        "phone": {
-          "primary": "05555 555 555"
-        },
-        "company": {}
+      "name": {
+        "first": "Enid",
+        "last": "Blyton"
+      },
+      "email": "famousfive@example.com",
+      "phone": {
+        "primary": "05555 555 555"
       },
       "address": {
         "sameAsSiteAddress": true

--- a/examples/validPlanningPermission.json
+++ b/examples/validPlanningPermission.json
@@ -33,16 +33,13 @@
     },
     "applicant": {
       "type": "individual",
-      "contact": {
-        "name": {
-          "first": "David",
-          "last": "Bowie"
-        },
-        "email": "ziggy@example.com",
-        "phone": {
-          "primary": "Not provided by agent"
-        },
-        "company": {}
+      "name": {
+        "first": "David",
+        "last": "Bowie"
+      },
+      "email": "ziggy@example.com",
+      "phone": {
+        "primary": "Not provided by agent"
       },
       "address": {
         "sameAsSiteAddress": true
@@ -55,16 +52,13 @@
         "certificate": "a"
       },
       "agent": {
-        "contact": {
-          "name": {
-            "first": "Ziggy",
-            "last": "Stardust"
-          },
-          "email": "ziggy@example.com",
-          "phone": {
-            "primary": "01100 0110 0011"
-          },
-          "company": {}
+        "name": {
+          "first": "Ziggy",
+          "last": "Stardust"
+        },
+        "email": "ziggy@example.com",
+        "phone": {
+          "primary": "01100 0110 0011"
         },
         "address": {
           "line1": "40 Stansfield Road",

--- a/examples/validPriorApproval.json
+++ b/examples/validPriorApproval.json
@@ -34,18 +34,16 @@
     },
     "applicant": {
       "type": "company",
-      "contact": {
-        "name": {
-          "first": "William",
-          "last": "Shakespeare"
-        },
-        "email": "thebard@example.com",
-        "phone": {
-          "primary": "2830407283"
-        },
-        "company": {
-          "name": "Lord Chamberlain's Men"
-        }
+      "name": {
+        "first": "William",
+        "last": "Shakespeare"
+      },
+      "email": "thebard@example.com",
+      "phone": {
+        "primary": "2830407283"
+      },
+      "company": {
+        "name": "Lord Chamberlain's Men"
       },
       "address": {
         "sameAsSiteAddress": true

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -3,10 +3,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
-    "AddressInput": {
-      "$id": "#AddressInput",
+    "Address": {
+      "$id": "#Address",
       "additionalProperties": false,
-      "description": "Address information for a personal contact not necessarily associated with the site",
+      "description": "Address information for a person associated with this application not at the property address",
       "properties": {
         "country": {
           "type": "string"
@@ -37,7 +37,7 @@
     "Agent": {
       "$id": "#Agent",
       "additionalProperties": false,
-      "description": "Information about the user who completed the application on behalf of someone else",
+      "description": "Information about the agent or proxy who completed the application on behalf of someone else",
       "properties": {
         "address": {
           "$ref": "#/definitions/UserAddress"
@@ -46,20 +46,77 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/AddressInput"
+              "$ref": "#/definitions/Address"
             },
-            "contact": {
-              "$ref": "#/definitions/UserContact"
+            "company": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "email": {
+              "$ref": "#/definitions/Email"
+            },
+            "name": {
+              "additionalProperties": false,
+              "properties": {
+                "first": {
+                  "type": "string"
+                },
+                "last": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "first",
+                "last"
+              ],
+              "type": "object"
+            },
+            "phone": {
+              "additionalProperties": false,
+              "properties": {
+                "primary": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "primary"
+              ],
+              "type": "object"
             }
           },
           "required": [
-            "contact",
+            "name",
+            "email",
+            "phone",
             "address"
           ],
           "type": "object"
         },
-        "contact": {
-          "$ref": "#/definitions/UserContact"
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
         },
         "interest": {
           "enum": [
@@ -71,8 +128,39 @@
           ],
           "type": "string"
         },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
         "ownership": {
           "$ref": "#/definitions/Ownership"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
         },
         "siteContact": {
           "$ref": "#/definitions/SiteContact"
@@ -91,7 +179,9 @@
       "required": [
         "address",
         "agent",
-        "contact",
+        "email",
+        "name",
+        "phone",
         "siteContact",
         "type"
       ],
@@ -921,8 +1011,20 @@
         "address": {
           "$ref": "#/definitions/UserAddress"
         },
-        "contact": {
-          "$ref": "#/definitions/UserContact"
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
         },
         "interest": {
           "enum": [
@@ -934,8 +1036,39 @@
           ],
           "type": "string"
         },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
         "ownership": {
           "$ref": "#/definitions/Ownership"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
         },
         "siteContact": {
           "$ref": "#/definitions/SiteContact"
@@ -953,7 +1086,9 @@
       },
       "required": [
         "type",
-        "contact",
+        "name",
+        "email",
+        "phone",
         "address",
         "siteContact"
       ],
@@ -2935,7 +3070,7 @@
     "Ownership": {
       "$id": "#Ownership",
       "additionalProperties": false,
-      "description": "Information about the ownership certificate and owners, if different than the applicant",
+      "description": "Information about the ownership certificate and property owners, if different than the applicant",
       "properties": {
         "certificate": {
           "enum": [
@@ -2956,7 +3091,7 @@
               "address": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/AddressInput"
+                    "$ref": "#/definitions/Address"
                   },
                   {
                     "type": "string"
@@ -18163,7 +18298,7 @@
     "UserAddressNotSameSite": {
       "$id": "#UserAddressNotSameSite",
       "additionalProperties": false,
-      "description": "Address information for an applicant with contact information that differs from the site address",
+      "description": "Address information for an applicant with contact information that differs from the property address",
       "properties": {
         "country": {
           "type": "string"
@@ -18193,62 +18328,6 @@
         "postcode",
         "sameAsSiteAddress",
         "town"
-      ],
-      "type": "object"
-    },
-    "UserContact": {
-      "$id": "#UserContact",
-      "additionalProperties": false,
-      "description": "Contact information for any user",
-      "properties": {
-        "company": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "email": {
-          "$ref": "#/definitions/Email"
-        },
-        "name": {
-          "additionalProperties": false,
-          "properties": {
-            "first": {
-              "type": "string"
-            },
-            "last": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "first",
-            "last"
-          ],
-          "type": "object"
-        },
-        "phone": {
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "primary"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "name",
-        "email",
-        "phone"
       ],
       "type": "object"
     },

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -43,7 +43,7 @@ describe("parsing using the 'ajv' library", () => {
   examplesToTest.forEach(example => {
     test(`accepts a valid example: ${example.data.application.type.description}`, () => {
       // addFormats() is required for types UUID, email, datetime etc
-      const ajv = addFormats(new Ajv());
+      const ajv = addFormats(new Ajv({allowUnionTypes: true}));
       const validate = ajv.compile(generatedSchema);
       const isValid = validate(example);
 

--- a/types/schema/data/Applicant.ts
+++ b/types/schema/data/Applicant.ts
@@ -13,43 +13,6 @@ export type Applicant = BaseApplicant | Agent;
  */
 export interface BaseApplicant {
   type: 'individual' | 'company' | 'charity' | 'public' | 'parishCouncil';
-  interest?: 'owner.sole' | 'owner.co' | 'tenant' | 'occupier' | 'other';
-  ownership?: Ownership;
-  contact: UserContact;
-  address: UserAddress;
-  siteContact: SiteContact;
-}
-
-/**
- * @id #Ownership
- * @description Information about the ownership certificate and owners, if different than the applicant
- */
-export interface Ownership {
-  certificate: 'a' | 'b' | 'c' | 'd';
-  noticeGiven?: boolean;
-  owners?: {
-    name: string;
-    address: AddressInput | string;
-    noticeDate?: Date;
-  }[];
-}
-
-/**
- * @id #Agent
- * @description Information about the user who completed the application on behalf of someone else
- */
-export interface Agent extends BaseApplicant {
-  agent: {
-    contact: UserContact;
-    address: AddressInput;
-  };
-}
-
-/**
- * @id #UserContact
- * @description Contact information for any user
- */
-export interface UserContact {
   name: {
     title?: string;
     first: string;
@@ -60,15 +23,55 @@ export interface UserContact {
     primary: string; // @todo only require for BaseApplicant OR Agent, not both
   };
   company?: {
-    name?: string;
+    name: string;
+  };
+  address: UserAddress;
+  interest?: 'owner.sole' | 'owner.co' | 'tenant' | 'occupier' | 'other';
+  ownership?: Ownership;
+  siteContact: SiteContact;
+}
+
+/**
+ * @id #Ownership
+ * @description Information about the ownership certificate and property owners, if different than the applicant
+ */
+export interface Ownership {
+  certificate: 'a' | 'b' | 'c' | 'd';
+  noticeGiven?: boolean;
+  owners?: {
+    name: string;
+    address: Address | string;
+    noticeDate?: Date;
+  }[];
+}
+
+/**
+ * @id #Agent
+ * @description Information about the agent or proxy who completed the application on behalf of someone else
+ */
+export interface Agent extends BaseApplicant {
+  agent: {
+    name: {
+      title?: string;
+      first: string;
+      last: string;
+    };
+    email: Email;
+    phone: {
+      primary: string;
+    };
+    company?: {
+      name: string;
+    };
+    address: Address;
   };
 }
 
 /**
- * @id #AddressInput
- * @description Address information for a personal contact not necessarily associated with the site
+ * @id #Address
+ * @description Address information for a person associated with this application not at the property address
  */
-export interface AddressInput {
+export interface Address {
   line1: string;
   line2?: string;
   town: string;
@@ -85,9 +88,9 @@ export type UserAddress = {sameAsSiteAddress: true} | UserAddressNotSameSite;
 
 /**
  * @id #UserAddressNotSameSite
- * @description Address information for an applicant with contact information that differs from the site address
+ * @description Address information for an applicant with contact information that differs from the property address
  */
-export interface UserAddressNotSameSite extends AddressInput {
+export interface UserAddressNotSameSite extends Address {
   sameAsSiteAddress: false;
 }
 


### PR DESCRIPTION
Emily spotted this one today while we were catching up about this work and how it relates to what editors define!

Removes `data.applicant.contact` & `data.applicant.agent.contact` and bumps keys like `name`, `email`, `phone`, `company` out to the main level consistent with Planx passport heirarchy. There wasn't any particularly good reason to wrap within `contact` in the first place. 

Once merged and published, I'll update migration guides accordingly (it's unlikely anyone has started parsing yet).