### PR TITLE
fix: better type for Responses `policyRef`

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -2857,14 +2857,7 @@
           "description": "Details of the digital planning service which sent the application",
           "properties": {
             "flowId": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/UUID"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/definitions/UUID"
             },
             "name": {
               "type": "string"
@@ -2891,14 +2884,7 @@
               "$ref": "#/definitions/DateTime"
             },
             "id": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/UUID"
-                },
-                {
-                  "type": "string"
-                }
-              ]
+              "$ref": "#/definitions/UUID"
             },
             "source": {
               "const": "PlanX",
@@ -17507,9 +17493,12 @@
                 "type": "string"
               },
               "url": {
-                "type": "string"
+                "$ref": "#/definitions/URL"
               }
             },
+            "required": [
+              "text"
+            ],
             "type": "object"
           },
           "type": "array"

--- a/types/schema/Metadata.ts
+++ b/types/schema/Metadata.ts
@@ -1,14 +1,14 @@
 import {DateTime, URL, UUID} from './../utils';
 
-/**
- * @id #DigitalPlanningMetadata
- * @description Details of the digital planning service which sent the application
- */
 export interface Metadata {
+  /**
+   * @id #DigitalPlanningMetadata
+   * @description Details of the digital planning service which sent the application
+   */
   service: {
-    flowId: UUID;
+    flowId: UUID | string; // @todo temp fix for failing UUID validation, sort out and tighten
     name: string;
-    organisation: string;
+    owner: string;
     url: URL;
   };
   session: {
@@ -16,7 +16,7 @@ export interface Metadata {
      * @default PlanX
      */
     source: 'PlanX';
-    id: UUID;
+    id: UUID | string;
     createdAt: DateTime;
     submittedAt?: DateTime;
   };

--- a/types/schema/Metadata.ts
+++ b/types/schema/Metadata.ts
@@ -1,14 +1,14 @@
 import {DateTime, URL, UUID} from './../utils';
 
+/**
+ * @id #DigitalPlanningMetadata
+ * @description Details of the digital planning service which sent the application
+ */
 export interface Metadata {
-  /**
-   * @id #DigitalPlanningMetadata
-   * @description Details of the digital planning service which sent the application
-   */
   service: {
-    flowId: UUID | string; // @todo temp fix for failing UUID validation, sort out and tighten
+    flowId: UUID;
     name: string;
-    owner: string;
+    organisation: string;
     url: URL;
   };
   session: {
@@ -16,7 +16,7 @@ export interface Metadata {
      * @default PlanX
      */
     source: 'PlanX';
-    id: UUID | string;
+    id: UUID;
     createdAt: DateTime;
     submittedAt?: DateTime;
   };

--- a/types/schema/Responses.ts
+++ b/types/schema/Responses.ts
@@ -1,4 +1,4 @@
-import { URL } from './../utils';
+import {URL} from './../utils';
 
 /**
  * @id #Responses

--- a/types/schema/Responses.ts
+++ b/types/schema/Responses.ts
@@ -1,3 +1,5 @@
+import { URL } from './../utils';
+
 /**
  * @id #Responses
  * @description The ordered list of questions, answers, and their metadata for the application
@@ -7,14 +9,14 @@ export type Responses = QuestionAndResponses[];
 export interface QuestionMetaData {
   autoAnswered?: boolean;
   policyRefs?: Array<{
-    url?: string;
-    text?: string;
+    text: string;
+    url?: URL;
   }>;
   sectionName?: string;
 }
 
 export interface ResponseMetaData {
-  flags?: Array<string>; // @todo connect to result/flags enum
+  flags?: Array<string>; // @todo connect to result/flags enum, is this actually a list?
   options?: Array<string> | Array<Response>;
 }
 


### PR DESCRIPTION
- `url` is proper `URL` type, rather than `string`
- `text` is always required if `policyRef` is available (might be case for `url` too once examples are updated? but not sure this is actually a planx content requirement!)