### PR TITLE
fix: update organisation to align to Planning Data reference code

### DIFF
--- a/examples/data/ldcE.ts
+++ b/examples/data/ldcE.ts
@@ -1227,7 +1227,7 @@ export const validLDCE: Schema = {
     },
   ],
   metadata: {
-    organisation: 'buckinghamshire',
+    organisation: 'BKM',
     id: '95f90e21-93f5-4761-90b3-815c673e041f',
     source: 'PlanX',
     service: {

--- a/examples/data/ldcP.ts
+++ b/examples/data/ldcP.ts
@@ -831,7 +831,7 @@ export const validLDCP: Schema = {
     },
   ],
   metadata: {
-    organisation: 'buckinghamshire',
+    organisation: 'BKM',
     id: '8da51c5b-a2a0-4386-a15d-29d66f9c121c',
     source: 'PlanX',
     service: {

--- a/examples/data/planningPermission.ts
+++ b/examples/data/planningPermission.ts
@@ -1249,7 +1249,7 @@ export const validPlanningPermission: Schema = {
     },
   ],
   metadata: {
-    organisation: 'lambeth',
+    organisation: 'LBH',
     id: '81bcaa0f-baf5-4573-ba0a-ea868c573faf',
     source: 'PlanX',
     service: {

--- a/examples/data/priorApproval.ts
+++ b/examples/data/priorApproval.ts
@@ -767,7 +767,7 @@ export const validPriorApproval: Schema = {
     },
   ],
   metadata: {
-    organisation: 'southwark',
+    organisation: 'SWK',
     id: 'b18c301b-9d44-4c6c-8d27-5b5bf33c570b',
     source: 'PlanX',
     service: {

--- a/examples/validLawfulDevelopmentCertificateExisting.json
+++ b/examples/validLawfulDevelopmentCertificateExisting.json
@@ -1849,7 +1849,7 @@
     }
   ],
   "metadata": {
-    "organisation": "buckinghamshire",
+    "organisation": "BKM",
     "id": "95f90e21-93f5-4761-90b3-815c673e041f",
     "source": "PlanX",
     "service": {

--- a/examples/validLawfulDevelopmentCertificateProposed.json
+++ b/examples/validLawfulDevelopmentCertificateProposed.json
@@ -1211,7 +1211,7 @@
     }
   ],
   "metadata": {
-    "organisation": "buckinghamshire",
+    "organisation": "BKM",
     "id": "8da51c5b-a2a0-4386-a15d-29d66f9c121c",
     "source": "PlanX",
     "service": {

--- a/examples/validPlanningPermission.json
+++ b/examples/validPlanningPermission.json
@@ -1760,7 +1760,7 @@
     }
   ],
   "metadata": {
-    "organisation": "lambeth",
+    "organisation": "LBH",
     "id": "81bcaa0f-baf5-4573-ba0a-ea868c573faf",
     "source": "PlanX",
     "service": {

--- a/examples/validPriorApproval.json
+++ b/examples/validPriorApproval.json
@@ -1097,7 +1097,7 @@
     }
   ],
   "metadata": {
-    "organisation": "southwark",
+    "organisation": "SWK",
     "id": "b18c301b-9d44-4c6c-8d27-5b5bf33c570b",
     "source": "PlanX",
     "service": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1167,7 +1167,8 @@
           "description": "Unique identifier for this application"
         },
         "organisation": {
-          "description": "UK Local Authority that this application is being submitted to",
+          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
+          "maxLength": 4,
           "type": "string"
         },
         "schema": {
@@ -3140,7 +3141,8 @@
           "description": "Unique identifier for this application"
         },
         "organisation": {
-          "description": "UK Local Authority that this application is being submitted to",
+          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
+          "maxLength": 4,
           "type": "string"
         },
         "schema": {

--- a/types/schema/Metadata.ts
+++ b/types/schema/Metadata.ts
@@ -12,9 +12,10 @@ export type Metadata = BaseMetadata | PlanXMetadata;
  */
 export interface BaseMetadata {
   /**
-   * @description UK Local Authority that this application is being submitted to
+   * @description The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority
+   * @maxLength 4
    */
-  organisation: string; // @todo align to DLUHC Planning Application API curie
+  organisation: string;
   /**
    * @description Unique identifier for this application
    */


### PR DESCRIPTION
Sourced from `reference` property here https://www.planning.data.gov.uk/entity.json?dataset=local-authority&limit=500

This [specification](https://digital-land.github.io/specification/specification/planning-application/) cites "reference code", but I'm honestly not exactly sure how I'd format this as a CURIE in JSON Schema - but this string should be a better alignment for now?

See #53 

I'll open a corresponding Planx PR to decide how to deal with this there: fetch & store at same point we get `local-authority-district` or store statically within `teams` db table & query with other metadata in planx-core? 