### PR TITLE
fix: add `data.applicant.ownership.noticeReason` and describe `data.property.boundary` & `data.proposal.boundary`

### DIFF
--- a/examples/validLawfulDevelopmentCertificateExisting.json
+++ b/examples/validLawfulDevelopmentCertificateExisting.json
@@ -1856,7 +1856,7 @@
       "flowId": "824628b2-deeb-48b0-92b1-2ca7f3b17163",
       "url": "https://www.editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview"
     },
-    "submittedAt": "2023-10-02 00:00:00",
+    "submittedAt": "2023-10-02t00:00:00z",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"
   }
 }

--- a/examples/validLawfulDevelopmentCertificateProposed.json
+++ b/examples/validLawfulDevelopmentCertificateProposed.json
@@ -1218,7 +1218,7 @@
       "flowId": "824628b2-deeb-48b0-92b1-2ca7f3b17163",
       "url": "https://www.editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview"
     },
-    "submittedAt": "2023-10-02 00:00:00",
+    "submittedAt": "2023-10-02T00:00:00+01:00",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"
   }
 }

--- a/examples/validPlanningPermission.json
+++ b/examples/validPlanningPermission.json
@@ -1767,7 +1767,7 @@
       "flowId": "01e38c5d-e701-4e44-acdc-4d6b5cc3b854",
       "url": "https://www.editor.planx.dev/lambeth/apply-for-planning-permission/preview"
     },
-    "submittedAt": "2023-10-02 00:00:00",
+    "submittedAt": "2023-10-02T00:00:00.00Z",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"
   }
 }

--- a/examples/validPriorApproval.json
+++ b/examples/validPriorApproval.json
@@ -1104,7 +1104,7 @@
       "flowId": "c6628103-c648-4663-81e1-bfa0a1a18340",
       "url": "https://www.editor.planx.dev/southwark/apply-for-prior-approval/preview"
     },
-    "submittedAt": "2023-10-02 00:00:00",
+    "submittedAt": "2023-10-02T00:00:00Z",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"
   }
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -2829,6 +2829,7 @@
         },
         "boundary": {
           "additionalProperties": false,
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary",
           "properties": {
             "area": {
               "$ref": "#/definitions/Area"
@@ -3133,6 +3134,9 @@
         },
         "noticeGiven": {
           "type": "boolean"
+        },
+        "noticeReason": {
+          "type": "string"
         },
         "owners": {
           "items": {
@@ -5309,6 +5313,42 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Change a fence, wall or gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.alter",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove a fence, wall, or gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.remove",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Repair a fence, wall or gate",
               "type": "string"
             },
@@ -5543,11 +5583,47 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add a high verandah or deck",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.decksHigh",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Work on drains",
               "type": "string"
             },
             "value": {
               "const": "alter.drains",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install equipment",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment",
               "type": "string"
             }
           },
@@ -5903,6 +5979,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Install internet equipment",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.wifi",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Install a wind turbine",
               "type": "string"
             },
@@ -5926,6 +6020,24 @@
             },
             "value": {
               "const": "alter.facades",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the insulation of the facade",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.facades.insulation",
               "type": "string"
             }
           },
@@ -5980,6 +6092,24 @@
             },
             "value": {
               "const": "alter.facades.reclad",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair the facade",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.facades.repair",
               "type": "string"
             }
           },
@@ -6051,6 +6181,24 @@
               "type": "string"
             },
             "value": {
+              "const": "alter.highways.dropKerb",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Changes to a dropped kerb",
+              "type": "string"
+            },
+            "value": {
               "const": "alter.highways.droppedKerb",
               "type": "string"
             }
@@ -6088,6 +6236,78 @@
             },
             "value": {
               "const": "alter.highways.droppedKerb.remove",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Changes to a road",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.road",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a road",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.road.add",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove a road",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.road.remove",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Changes to internal walls or layout",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.internal",
               "type": "string"
             }
           },
@@ -6281,11 +6501,29 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add one or more new windows",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.windows",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add new windows to the front of the building",
               "type": "string"
             },
             "value": {
-              "const": "alter.openings.add.window.front",
+              "const": "alter.openings.add.windows.front",
               "type": "string"
             }
           },
@@ -6303,7 +6541,7 @@
               "type": "string"
             },
             "value": {
-              "const": "alter.openings.add.window.high",
+              "const": "alter.openings.add.windows.high",
               "type": "string"
             }
           },
@@ -6321,7 +6559,7 @@
               "type": "string"
             },
             "value": {
-              "const": "alter.openings.add.window.rear",
+              "const": "alter.openings.add.windows.rear",
               "type": "string"
             }
           },
@@ -6339,7 +6577,7 @@
               "type": "string"
             },
             "value": {
-              "const": "alter.openings.add.window.shutters",
+              "const": "alter.openings.add.windows.shutters",
               "type": "string"
             }
           },
@@ -6357,7 +6595,7 @@
               "type": "string"
             },
             "value": {
-              "const": "alter.openings.add.window.side",
+              "const": "alter.openings.add.windows.side",
               "type": "string"
             }
           },
@@ -6461,6 +6699,60 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Enlarge a window opening on the front of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.alter.enlarge.window.front",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Enlarge a window opening on the rear of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.alter.enlarge.window.rear",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Enlarge a window opening on the side of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.alter.enlarge.window.side",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Reduce the size of a door opening",
               "type": "string"
             },
@@ -6497,11 +6789,101 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Reduce the size of a window opening on the front of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.alter.reduce.window.front",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Reduce the size of a window opening on the rear of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.alter.reduce.window.rear",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Reduce the size of a window opening on the side of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.alter.reduce.window.side",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Block up doorways or windows",
               "type": "string"
             },
             "value": {
               "const": "alter.openings.remove",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Block up doorways",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.remove.door",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Block up windows",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.remove.window",
               "type": "string"
             }
           },
@@ -6574,6 +6956,24 @@
             },
             "value": {
               "const": "alter.remove.deck",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove a drain",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.remove.drain",
               "type": "string"
             }
           },
@@ -6749,11 +7149,119 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Replace door with door on the front of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.doorsToDoors.front",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace door with door on the rear of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.doorsToDoors.rear",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace door with door on the side of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.doorsToDoors.side",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Replace door with window",
               "type": "string"
             },
             "value": {
               "const": "alter.replace.doorsToWindows",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace door with window on the front of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.doorsToWindows.front",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace door with winoow on the rear of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.doorsToWindows.rear",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace door with window on the side of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.doorsToWindows.side",
               "type": "string"
             }
           },
@@ -6785,11 +7293,119 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Replace window with door on the front of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.windowsToDoors.front",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace window with door on the rear of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.windowsToDoors.rear",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace window with door on the side of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.windowsToDoors.side",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Replace window with window",
               "type": "string"
             },
             "value": {
               "const": "alter.replace.windowsToWindows",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace window with window on the front ofa building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.windowsToWindows.front",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace window with window on the rear of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.windowsToWindows.rear",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace window with window on the side of a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.replace.windowsToWindows.side",
               "type": "string"
             }
           },
@@ -7019,6 +7635,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add a low surface",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaceLow",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add a decked area or patio",
               "type": "string"
             },
@@ -7037,11 +7671,155 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add a decked area",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.deck",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add a driveway or parking area",
               "type": "string"
             },
             "value": {
               "const": "alter.surfaces.parking",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Extend a driveway or parking area",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.parking.extend",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a new driveway or parking area",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.parking.new",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace a driveway or parking area",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.parking.replace",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a patio",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.patio",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Extend a patio",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.patio.extend",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a new patio",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.patio.new",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace a patio",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.surfaces.patio.replace",
               "type": "string"
             }
           },
@@ -7127,6 +7905,168 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Changes to hedges",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.hedge",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Let hedges grow",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.hedge.letGrow",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "New hedges",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.hedge.new",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Prune hedges",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.hedge.prune",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove hedges",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.hedge.remove",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Changes to trees",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.tree",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "New trees",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.tree.new",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Prune trees",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.tree.prune",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove trees",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.trees.tree.remove",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Change the use of a building",
               "type": "string"
             },
@@ -7168,6 +8108,24 @@
             },
             "value": {
               "const": "changeOfUse.caravans",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Convert an extension",
+              "type": "string"
+            },
+            "value": {
+              "const": "changeOfUse.extension",
               "type": "string"
             }
           },
@@ -7271,11 +8229,11 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Convert a home to bedsits or a shared home",
+              "const": "Change the use of a property",
               "type": "string"
             },
             "value": {
-              "const": "changeOfUse.whole.homeToHMO",
+              "const": "changeOfUse.whole",
               "type": "string"
             }
           },
@@ -7289,11 +8247,11 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Change the use of a property",
+              "const": "Convert a home to bedsits or a shared home",
               "type": "string"
             },
             "value": {
-              "const": "changeOfUse.whole",
+              "const": "changeOfUse.whole.homeToHMO",
               "type": "string"
             }
           },
@@ -7383,6 +8341,24 @@
               "type": "string"
             },
             "value": {
+              "const": "demolish.outbuilding",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Demolish an outbuilding (such as a garage or barn)",
+              "type": "string"
+            },
+            "value": {
               "const": "demolish.outbuildings",
               "type": "string"
             }
@@ -7402,6 +8378,24 @@
             },
             "value": {
               "const": "demolish.part",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Demolish part of a conservatory",
+              "type": "string"
+            },
+            "value": {
+              "const": "demolish.part.conservatory",
               "type": "string"
             }
           },
@@ -7438,6 +8432,24 @@
             },
             "value": {
               "const": "extend",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Enlarge a balcony",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.balcony",
               "type": "string"
             }
           },
@@ -7505,11 +8517,389 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add a new basement extension",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.basement.new",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add a front extension",
               "type": "string"
             },
             "value": {
               "const": "extend.front",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding (such as a shed, garage or garden office)",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - animal enclosure, aviary or beehive",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.animals",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - residential (or \"granny\") annexe",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.annexe",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - bedroom or guest room",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.bedroom",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - games room",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.games",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - garage",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.garage",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - greenhouse",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.greenhouse",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - gym",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.gym",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - office",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.office",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - something else",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.other",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - play house",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.play",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - sauna",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.sauna",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - shed",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.shed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - car parking or smoking shelter",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.shelter",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - storage",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.store",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - studio",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.studio",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - summer house",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.summerHouse",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - swimming pool",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.swimmingPool",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - tank",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.tank",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - workshop",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuilding.workshop",
               "type": "string"
             }
           },
@@ -7690,6 +9080,24 @@
             },
             "value": {
               "const": "extend.outbuildings.other",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an outbuilding - play house",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.outbuildings.play",
               "type": "string"
             }
           },
@@ -8009,6 +9417,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Join two roofs",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.connect",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add a roof dormer",
               "type": "string"
             },
@@ -8117,7 +9543,25 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Hip-to-gable roof enlargement",
+              "const": "Convert a hip roof to a gable",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.hiptogable",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Convert a hip roof to a gable",
               "type": "string"
             },
             "value": {
@@ -8135,11 +9579,83 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Convert to a mansard roof",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.mansard",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add one or more new storeys",
               "type": "string"
             },
             "value": {
-              "const": "exend.roof.newStorey",
+              "const": "extend.roof.newstorey",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add one or more new storeys",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.newStorey",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Convert to a sloping roof",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.slope",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a side extension",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.side",
               "type": "string"
             }
           },
@@ -8333,7 +9849,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Add another type of building",
+              "const": "Add a new separate building or self-contained units",
               "type": "string"
             },
             "value": {
@@ -8351,7 +9867,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Agricultural buildings",
+              "const": "New agricultural buildings",
               "type": "string"
             },
             "value": {
@@ -8369,7 +9885,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Agricultural buildings - glass house",
+              "const": "New agricultural buildings - glass house",
               "type": "string"
             },
             "value": {
@@ -8387,7 +9903,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Agricultural buildings - mining",
+              "const": "New agricultural buildings - mining",
               "type": "string"
             },
             "value": {
@@ -8405,7 +9921,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Agricultural buildings - pigs",
+              "const": "New agricultural buildings - pigs",
               "type": "string"
             },
             "value": {
@@ -8423,7 +9939,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Agricultural buildings - poultry",
+              "const": "New agricultural buildings - poultry",
               "type": "string"
             },
             "value": {
@@ -8531,7 +10047,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Industrial premises",
+              "const": "New industrial premises",
               "type": "string"
             },
             "value": {
@@ -8549,7 +10065,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Leisure premises",
+              "const": "New leisure premises",
               "type": "string"
             },
             "value": {
@@ -8567,11 +10083,29 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Offices",
+              "const": "New offices",
               "type": "string"
             },
             "value": {
               "const": "new.office",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add another type of building - something else",
+              "type": "string"
+            },
+            "value": {
+              "const": "new.other",
               "type": "string"
             }
           },
@@ -8603,7 +10137,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Retail premises",
+              "const": "New retail premises",
               "type": "string"
             },
             "value": {
@@ -8657,11 +10191,65 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Storage or distribution premises",
+              "const": "New storage or distribution premises",
               "type": "string"
             },
             "value": {
               "const": "new.warehouse",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Negate a project type",
+              "type": "string"
+            },
+            "value": {
+              "const": "not",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Do not add or change windows or doors",
+              "type": "string"
+            },
+            "value": {
+              "const": "not.alter.replace",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Do not add or change a rooflight",
+              "type": "string"
+            },
+            "value": {
+              "const": "not.alter.rooflight",
               "type": "string"
             }
           },
@@ -17105,6 +18693,7 @@
       "properties": {
         "boundary": {
           "additionalProperties": false,
+          "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary",
           "properties": {
             "area": {
               "$ref": "#/definitions/Area"
@@ -17932,6 +19521,7 @@
         },
         "boundary": {
           "additionalProperties": false,
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary",
           "properties": {
             "area": {
               "$ref": "#/definitions/Area"

--- a/types/schema/data/Applicant.ts
+++ b/types/schema/data/Applicant.ts
@@ -38,6 +38,7 @@ export interface BaseApplicant {
 export interface Ownership {
   certificate: 'a' | 'b' | 'c' | 'd';
   noticeGiven?: boolean;
+  noticeReason?: string;
   owners?: {
     name: string;
     address: Address | string;

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -36,6 +36,9 @@ export interface UKProperty {
    */
   localAuthorityDistrict: string[];
   type: PropertyType;
+  /**
+   * @description HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary
+   */
   boundary?: {
     site: GeoJSON;
     area: Area;

--- a/types/schema/data/Proposal.ts
+++ b/types/schema/data/Proposal.ts
@@ -10,6 +10,9 @@ import {Area, Date} from '../../utils';
 export interface Proposal {
   projectType: ProjectType[];
   description: string;
+  /**
+   * @description Location plan boundary proposed by the user, commonly referred to as the red line boundary
+   */
   boundary?: {
     site: GeoJSON;
     area: Area;


### PR DESCRIPTION
Two small tweaks:
- `noticeReason` was requested from BOPS here https://opendigitalplanning.slack.com/archives/C0182MVK4AW/p1700148320500969
- Boundary descriptions better describe our new data sources now! We'll still only be populating `proposal.boundary` until title's are "live" on Planx