### PR TITLE
v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The minor version will be incremented upon a breaking change and the patch version will be
 incremented for features.
 
+## [0.2.3] - 2024-01-29
+
+### Added 
+- Added additional `PlanningDesignations` ([#99](https://github.com/theopensystemslab/digital-planning-data-schemas/pull/99))
+- Added additional `ApplicationTypes`. Stay tuned for expanded example payloads in the next release! ([#98](https://github.com/theopensystemslab/digital-planning-data-schemas/pull/98))
+
 ## [0.2.2] - 2023-12-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-planning-data-schemas",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Digital Planning Data schemas",
   "main": "schema/schema.json",
   "scripts": {


### PR DESCRIPTION
Captures expanded `PlanningDesignations` & `ApplicationsTypes` enums as these are purely additive changes, intentionally omits `FileTypes` changes for now as I expect this will introduce a few breaking changes.