### PR TITLE
fix: correct typo in `FileTypes`

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -2769,11 +2769,11 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Statuatory declaration",
+              "const": "Statutory declaration",
               "type": "string"
             },
             "value": {
-              "const": "statuatoryDeclaration",
+              "const": "statutoryDeclaration",
               "type": "string"
             }
           },

--- a/types/enums/FileTypes.ts
+++ b/types/enums/FileTypes.ts
@@ -63,7 +63,7 @@ export const FileTypes = {
   'sitePlan.proposed': 'Site plan - proposed',
   sketchPlan: 'Sketch plan',
   statementOfCommunityInvolvement: 'Statement of community involvement',
-  statuatoryDeclaration: 'Statuatory declaration',
+  statutoryDeclaration: 'Statutory declaration',
   storageTreatmentAndWasteDisposalDetails:
     'Details of storage treatment or disposal of waste',
   streetScene: 'Street scene drawing',


### PR DESCRIPTION
Found while updating BOPS v1 tagging