### PR TITLE
fix: add step to Github Action publish workflow to update version across example files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,14 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }}/examples"
           mv examples/*.json "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }}/examples"
 
+      - name: Find and Replace @next with VERSION in /examples
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "@next"
+          replace: "v${{ steps.version_check.outputs.version }}"
+          include: "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }}/examples"
+          regex: false
+
       - name: Checkout Dist Branch
         if: steps.version_check.outputs.changed == 'true'
         run: |


### PR DESCRIPTION
I think this should work, but admittedly haven't tried queuing up a release to test it ! Ideas ofr testing locally, or we just test on next release?

See #114

If this doesn't work, we can alternatively try editing `scripts/build-json-examples.ts` - but this script isn't currently aware of the current schema version (`$id`), which differs from package.json version - so felt like the more complicated route.