### PR TITLE
fix: require `metadata.source` for any provider, not only Planx

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -187,6 +187,40 @@
       ],
       "type": "object"
     },
+    "AnyProviderMetadata": {
+      "$id": "#AnyProviderMetadata",
+      "additionalProperties": false,
+      "description": "Base metadata associated with applications submitted via any provider",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/UUID",
+          "description": "Unique identifier for this application"
+        },
+        "organisation": {
+          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
+          "maxLength": 4,
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/URL"
+        },
+        "source": {
+          "const": "Any",
+          "type": "string"
+        },
+        "submittedAt": {
+          "$ref": "#/definitions/DateTime"
+        }
+      },
+      "required": [
+        "id",
+        "organisation",
+        "schema",
+        "source",
+        "submittedAt"
+      ],
+      "type": "object"
+    },
     "Applicant": {
       "$id": "#Applicant",
       "anyOf": [
@@ -1569,35 +1603,6 @@
           "type": "object"
         }
       },
-      "type": "object"
-    },
-    "BaseMetadata": {
-      "$id": "#BaseMetadata",
-      "additionalProperties": false,
-      "description": "Minimum metadata expected for any application",
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/UUID",
-          "description": "Unique identifier for this application"
-        },
-        "organisation": {
-          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
-          "maxLength": 4,
-          "type": "string"
-        },
-        "schema": {
-          "$ref": "#/definitions/URL"
-        },
-        "submittedAt": {
-          "$ref": "#/definitions/DateTime"
-        }
-      },
-      "required": [
-        "organisation",
-        "id",
-        "submittedAt",
-        "schema"
-      ],
       "type": "object"
     },
     "Date": {
@@ -4173,7 +4178,7 @@
       "$id": "#DigitalPlanningMetadata",
       "anyOf": [
         {
-          "$ref": "#/definitions/BaseMetadata"
+          "$ref": "#/definitions/AnyProviderMetadata"
         },
         {
           "$ref": "#/definitions/PlanXMetadata"

--- a/types/schema/Metadata.ts
+++ b/types/schema/Metadata.ts
@@ -5,7 +5,7 @@ import {FileType} from './File';
  * @id #DigitalPlanningMetadata
  * @description Details of the digital planning service which sent this application
  */
-export type Metadata = BaseMetadata | PlanXMetadata;
+export type Metadata = AnyProviderMetadata | PlanXMetadata;
 
 /**
  * @id #BaseMetadata
@@ -23,6 +23,14 @@ export interface BaseMetadata {
   id: UUID; // @todo align to DLUHC Planning Application API reference
   submittedAt: DateTime;
   schema: URL;
+}
+
+/**
+ * @id #AnyProviderMetadata
+ * @description Base metadata associated with applications submitted via any provider
+ */
+export interface AnyProviderMetadata extends BaseMetadata {
+  source: 'Any';
 }
 
 /**


### PR DESCRIPTION
An alternative enum approach to #118 - no strong opinions, up for discussion ! 

The enum perhaps offers a slightly more clear "default" state as asked here https://github.com/theopensystemslab/digital-planning-data-schemas/issues/117#issuecomment-1941625221. "Any" very much feels like a placeholder until another user comes along and defines their own proper metadata (eg `'Any' | 'PlanX' | 'PlanningPortal'`)

Fixes #117 