### PR TITLE
chore: adjust `planning.designations.entities` "source" to include text and url

### DIFF
--- a/examples/data/ldcE.ts
+++ b/examples/data/ldcE.ts
@@ -166,7 +166,10 @@ export const validLDCE: Schema = {
                 name: 'Whole District excluding the Town of Chesham - Poultry production.',
                 description:
                   'Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.',
-                source: 'https://www.planning.data.gov.uk/entity/7010002192',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010002192',
+                },
               },
             ],
           },
@@ -238,7 +241,10 @@ export const validLDCE: Schema = {
             entities: [
               {
                 name: 'Chilterns',
-                source: 'https://www.planning.data.gov.uk/entity/1000005',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/1000005',
+                },
               },
             ],
           },

--- a/examples/data/priorApproval.ts
+++ b/examples/data/priorApproval.ts
@@ -113,31 +113,46 @@ export const validPriorApproval: Schema = {
                 name: 'Central Activities Zone',
                 description:
                   'Change of use from offices to dwelling houses is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010000942',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010000942',
+                },
               },
               {
                 name: 'Central Activities Zone',
                 description:
                   'Demolition of commercial buildings and construction of new dwellinghouses is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010000944',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010000944',
+                },
               },
               {
                 name: 'Bankside and Borough District Town Centre',
                 description:
                   'Demolition of commercial buildings and construction of new dwellinghouses is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010001042',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010001042',
+                },
               },
               {
                 name: 'Central Activities Zone',
                 description:
                   'Change of use from Class E to residential is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010001055',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010001055',
+                },
               },
               {
                 name: 'Bankside and Borough District Town Centre',
                 description:
                   'Change of use from Class E to residential is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010001153',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010001153',
+                },
               },
             ],
           },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4814,11 +4814,43 @@
                         "type": "string"
                       },
                       "source": {
-                        "$ref": "#/definitions/URL"
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "text": {
+                                "const": "Planning Data",
+                                "type": "string"
+                              },
+                              "url": {
+                                "$ref": "#/definitions/URL"
+                              }
+                            },
+                            "required": [
+                              "text",
+                              "url"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "text": {
+                                "const": "Ordnance Survey MasterMap Highways",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "type": "object"
+                          }
+                        ]
                       }
                     },
                     "required": [
-                      "name"
+                      "name",
+                      "source"
                     ],
                     "type": "object"
                   },
@@ -5524,11 +5556,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5578,11 +5642,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5632,11 +5728,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5686,11 +5814,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5740,11 +5900,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5794,11 +5986,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5848,11 +6072,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5902,11 +6158,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5956,11 +6244,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6010,11 +6330,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6064,11 +6416,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6118,11 +6502,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6172,11 +6588,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6226,11 +6674,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6280,11 +6760,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6334,11 +6846,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6388,11 +6932,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6442,11 +7018,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6496,11 +7104,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6550,11 +7190,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6604,11 +7276,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6658,11 +7362,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6712,11 +7448,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6766,11 +7534,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6820,11 +7620,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6874,11 +7706,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6928,11 +7792,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6982,11 +7878,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1563,6 +1563,72 @@
     "BaseDetails": {
       "additionalProperties": false,
       "properties": {
+        "access": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "public": {
+              "description": "Is the property accessible from public land?",
+              "type": "boolean"
+            },
+            "type": {
+              "items": {
+                "enum": [
+                  "vehicle",
+                  "parking",
+                  "newRoad",
+                  "rightsOfWay.newPublic",
+                  "rightsOfWay.changeOfUse"
+                ],
+                "type": "string"
+              },
+              "maxItems": 1,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "type",
+            "description"
+          ],
+          "type": "object"
+        },
+        "demolish": {
+          "additionalProperties": false,
+          "properties": {
+            "asbestosAffected": {
+              "description": "Are materials containing asbestos affected by the demolition?",
+              "type": "boolean"
+            },
+            "dangerousStructure": {
+              "description": "Is a dangerous structure being demolished?",
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "remediationPlan": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "ecology": {
+          "additionalProperties": false,
+          "properties": {
+            "livestock": {
+              "description": "Is the development housing livestock?",
+              "type": "boolean"
+            },
+            "otherSpecies": {
+              "description": "Are known species inhabiting the site?",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
         "extend": {
           "additionalProperties": false,
           "properties": {
@@ -1573,6 +1639,40 @@
           "required": [
             "area"
           ],
+          "type": "object"
+        },
+        "flood": {
+          "additionalProperties": false,
+          "properties": {
+            "surfaceWaterDisposal": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "items": {
+                    "enum": [
+                      "drainageSystem",
+                      "soakaway",
+                      "sewer",
+                      "watercourse",
+                      "pondOrLake"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 1,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "description"
+              ],
+              "type": "object"
+            }
+          },
           "type": "object"
         },
         "new": {
@@ -1600,6 +1700,53 @@
           "required": [
             "area"
           ],
+          "type": "object"
+        },
+        "trees": {
+          "additionalProperties": false,
+          "properties": {
+            "affected": {
+              "description": "Are trees or hedges being cut down or pruned?",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "utilities": {
+          "additionalProperties": false,
+          "properties": {
+            "buildOver": {
+              "description": "Is the development building over existing utilities?",
+              "type": "boolean"
+            },
+            "foulSewageDisposal": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "items": {
+                    "enum": [
+                      "sewer",
+                      "tank",
+                      "plant",
+                      "pit"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 1,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "description"
+              ],
+              "type": "object"
+            }
+          },
           "type": "object"
         }
       },
@@ -3098,6 +3245,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Tree survey",
+              "type": "string"
+            },
+            "value": {
+              "const": "treeSurvey",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Unit plan - existing",
               "type": "string"
             },
@@ -3384,6 +3549,72 @@
       "additionalProperties": false,
       "description": "Proposal details for project sites within the Greater London Authority (GLA) area",
       "properties": {
+        "access": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "public": {
+              "description": "Is the property accessible from public land?",
+              "type": "boolean"
+            },
+            "type": {
+              "items": {
+                "enum": [
+                  "vehicle",
+                  "parking",
+                  "newRoad",
+                  "rightsOfWay.newPublic",
+                  "rightsOfWay.changeOfUse"
+                ],
+                "type": "string"
+              },
+              "maxItems": 1,
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "type",
+            "description"
+          ],
+          "type": "object"
+        },
+        "demolish": {
+          "additionalProperties": false,
+          "properties": {
+            "asbestosAffected": {
+              "description": "Are materials containing asbestos affected by the demolition?",
+              "type": "boolean"
+            },
+            "dangerousStructure": {
+              "description": "Is a dangerous structure being demolished?",
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "remediationPlan": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "ecology": {
+          "additionalProperties": false,
+          "properties": {
+            "livestock": {
+              "description": "Is the development housing livestock?",
+              "type": "boolean"
+            },
+            "otherSpecies": {
+              "description": "Are known species inhabiting the site?",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
         "extend": {
           "additionalProperties": false,
           "properties": {
@@ -3394,6 +3625,40 @@
           "required": [
             "area"
           ],
+          "type": "object"
+        },
+        "flood": {
+          "additionalProperties": false,
+          "properties": {
+            "surfaceWaterDisposal": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "items": {
+                    "enum": [
+                      "drainageSystem",
+                      "soakaway",
+                      "sewer",
+                      "watercourse",
+                      "pondOrLake"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 1,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "description"
+              ],
+              "type": "object"
+            }
+          },
           "type": "object"
         },
         "new": {
@@ -3421,6 +3686,53 @@
           "required": [
             "area"
           ],
+          "type": "object"
+        },
+        "trees": {
+          "additionalProperties": false,
+          "properties": {
+            "affected": {
+              "description": "Are trees or hedges being cut down or pruned?",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "utilities": {
+          "additionalProperties": false,
+          "properties": {
+            "buildOver": {
+              "description": "Is the development building over existing utilities?",
+              "type": "boolean"
+            },
+            "foulSewageDisposal": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "type": {
+                  "items": {
+                    "enum": [
+                      "sewer",
+                      "tank",
+                      "plant",
+                      "pit"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 1,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "description"
+              ],
+              "type": "object"
+            }
+          },
           "type": "object"
         },
         "vehicleParking": {

--- a/types/enums/FileTypes.ts
+++ b/types/enums/FileTypes.ts
@@ -82,6 +82,7 @@ export const FileTypes = {
   treeCanopyCalculator: 'Tree canopy calculator',
   treeConditionReport: 'Tree condition report',
   treesReport: 'Trees report',
+  treeSurvey: 'Tree survey',
   'unitPlan.existing': 'Unit plan - existing',
   'unitPlan.proposed': 'Unit plan - proposed',
   'usePlan.existing': 'Use plan - existing',

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -225,5 +225,14 @@ export type PlanningConstraint =
 type Entity = {
   name: string;
   description?: string;
-  source?: URL;
+  source: PlanningDataSource | OSRoadsSource;
+};
+
+type PlanningDataSource = {
+  text: 'Planning Data';
+  url: URL;
+};
+
+type OSRoadsSource = {
+  text: 'Ordnance Survey MasterMap Highways';
 };

--- a/types/schema/data/Proposal.ts
+++ b/types/schema/data/Proposal.ts
@@ -61,20 +61,52 @@ export interface BaseDetails {
     asbestosAffected?: boolean;
   };
   access?: {
-    type?: [
+    type: [
       | 'vehicle'
       | 'parking'
       | 'newRoad'
       | 'rightsOfWay.newPublic'
       | 'rightsOfWay.changeOfUse',
     ];
-    description?: string;
+    description: string;
+    /**
+     * @description Is the property accessible from public land?
+     */
+    public?: boolean;
   };
   trees?: {
     /**
-     * @description Will trees or hedges be cut down or pruned?
+     * @description Are trees or hedges being cut down or pruned?
      */
     affected?: boolean;
+  };
+  utilities?: {
+    /**
+     * @description Is the development building over existing utilities?
+     */
+    buildOver?: boolean;
+    foulSewageDisposal?: {
+      type: ['sewer' | 'tank' | 'plant' | 'pit'];
+      description: string;
+    };
+  };
+  flood?: {
+    surfaceWaterDisposal?: {
+      type: [
+        'drainageSystem' | 'soakaway' | 'sewer' | 'watercourse' | 'pondOrLake',
+      ];
+      description: string;
+    };
+  };
+  ecology?: {
+    /**
+     * @description Is the development housing livestock?
+     */
+    livestock?: boolean;
+    /**
+     * @description Are known species inhabiting the site?
+     */
+    otherSpecies?: boolean;
   };
 }
 

--- a/types/schema/data/Proposal.ts
+++ b/types/schema/data/Proposal.ts
@@ -48,6 +48,34 @@ export interface BaseDetails {
       dwellings?: number;
     };
   };
+  demolish?: {
+    reason?: string;
+    remediationPlan?: string;
+    /**
+     * @description Is a dangerous structure being demolished?
+     */
+    dangerousStructure?: boolean;
+    /**
+     * @description Are materials containing asbestos affected by the demolition?
+     */
+    asbestosAffected?: boolean;
+  };
+  access?: {
+    type?: [
+      | 'vehicle'
+      | 'parking'
+      | 'newRoad'
+      | 'rightsOfWay.newPublic'
+      | 'rightsOfWay.changeOfUse',
+    ];
+    description?: string;
+  };
+  trees?: {
+    /**
+     * @description Will trees or hedges be cut down or pruned?
+     */
+    affected?: boolean;
+  };
 }
 
 /**


### PR DESCRIPTION
Per feedback from BOPS, see thread: https://opendigitalplanning.slack.com/archives/C0634B4B8TT/p1707994154106899

`text` & `url` naming convention aligns to `responses` "policyRefs"