### PR TITLE
chore: adjust `planning.designations.entities` "source" to include text and url

### DIFF
--- a/examples/data/ldcE.ts
+++ b/examples/data/ldcE.ts
@@ -166,7 +166,10 @@ export const validLDCE: Schema = {
                 name: 'Whole District excluding the Town of Chesham - Poultry production.',
                 description:
                   'Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.',
-                source: 'https://www.planning.data.gov.uk/entity/7010002192',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010002192',
+                },
               },
             ],
           },
@@ -238,7 +241,10 @@ export const validLDCE: Schema = {
             entities: [
               {
                 name: 'Chilterns',
-                source: 'https://www.planning.data.gov.uk/entity/1000005',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/1000005',
+                },
               },
             ],
           },

--- a/examples/data/priorApproval.ts
+++ b/examples/data/priorApproval.ts
@@ -113,31 +113,46 @@ export const validPriorApproval: Schema = {
                 name: 'Central Activities Zone',
                 description:
                   'Change of use from offices to dwelling houses is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010000942',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010000942',
+                },
               },
               {
                 name: 'Central Activities Zone',
                 description:
                   'Demolition of commercial buildings and construction of new dwellinghouses is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010000944',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010000944',
+                },
               },
               {
                 name: 'Bankside and Borough District Town Centre',
                 description:
                   'Demolition of commercial buildings and construction of new dwellinghouses is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010001042',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010001042',
+                },
               },
               {
                 name: 'Central Activities Zone',
                 description:
                   'Change of use from Class E to residential is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010001055',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010001055',
+                },
               },
               {
                 name: 'Bankside and Borough District Town Centre',
                 description:
                   'Change of use from Class E to residential is restricted',
-                source: 'https://www.planning.data.gov.uk/entity/7010001153',
+                source: {
+                  text: 'Planning Data',
+                  url: 'https://www.planning.data.gov.uk/entity/7010001153',
+                },
               },
             ],
           },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4502,11 +4502,43 @@
                         "type": "string"
                       },
                       "source": {
-                        "$ref": "#/definitions/URL"
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "text": {
+                                "const": "Planning Data",
+                                "type": "string"
+                              },
+                              "url": {
+                                "$ref": "#/definitions/URL"
+                              }
+                            },
+                            "required": [
+                              "text",
+                              "url"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "text": {
+                                "const": "Ordnance Survey MasterMap Highways",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "type": "object"
+                          }
+                        ]
                       }
                     },
                     "required": [
-                      "name"
+                      "name",
+                      "source"
                     ],
                     "type": "object"
                   },
@@ -5212,11 +5244,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5266,11 +5330,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5320,11 +5416,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5374,11 +5502,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5428,11 +5588,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5482,11 +5674,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5536,11 +5760,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5590,11 +5846,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5644,11 +5932,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5698,11 +6018,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5752,11 +6104,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5806,11 +6190,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5860,11 +6276,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5914,11 +6362,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -5968,11 +6448,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6022,11 +6534,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6076,11 +6620,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6130,11 +6706,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6184,11 +6792,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6238,11 +6878,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6292,11 +6964,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6346,11 +7050,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6400,11 +7136,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6454,11 +7222,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6508,11 +7308,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6562,11 +7394,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6616,11 +7480,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },
@@ -6670,11 +7566,43 @@
                             "type": "string"
                           },
                           "source": {
-                            "$ref": "#/definitions/URL"
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Planning Data",
+                                    "type": "string"
+                                  },
+                                  "url": {
+                                    "$ref": "#/definitions/URL"
+                                  }
+                                },
+                                "required": [
+                                  "text",
+                                  "url"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "text": {
+                                    "const": "Ordnance Survey MasterMap Highways",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "text"
+                                ],
+                                "type": "object"
+                              }
+                            ]
                           }
                         },
                         "required": [
-                          "name"
+                          "name",
+                          "source"
                         ],
                         "type": "object"
                       },

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -225,5 +225,14 @@ export type PlanningConstraint =
 type Entity = {
   name: string;
   description?: string;
-  source?: URL;
+  source: PlanningDataSource | OSRoadsSource;
+};
+
+type PlanningDataSource = {
+  text: 'Planning Data';
+  url: URL;
+};
+
+type OSRoadsSource = {
+  text: 'Ordnance Survey MasterMap Highways';
 };


### PR DESCRIPTION
Per feedback from BOPS, see thread: https://opendigitalplanning.slack.com/archives/C0634B4B8TT/p1707994154106899

`text` & `url` naming convention aligns to "policyRefs" in `responses`