### PR TITLE
chore: add steps to pre-commit hook to build json examples & dev schema

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm build-json-examples
-pnpm build-schema:dev
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "main" ]; then
+	pnpm build-json-examples
+  pnpm build-schema:dev
+fi
+
 pnpm check && pnpm fix
 git add .

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+pnpm build-json-examples
+pnpm build-schema:dev
 pnpm check && pnpm fix
 git add .

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,8 +3,7 @@
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$branch" != "main" ]; then
-	pnpm build-json-examples
-  pnpm build-schema:dev
+  pnpm build-json-examples && pnpm build-schema:dev
 fi
 
 pnpm check && pnpm fix

--- a/examples/validLawfulDevelopmentCertificateExisting.json
+++ b/examples/validLawfulDevelopmentCertificateExisting.json
@@ -256,7 +256,10 @@
               {
                 "name": "Whole District excluding the Town of Chesham - Poultry production.",
                 "description": "Bucks County Council Town and Country Planning Act 1947 Town and Country Planning General Development Order 1950. Re Whole District excluding the Town of Chesham. In relation to poultry production.",
-                "source": "https://www.planning.data.gov.uk/entity/7010002192"
+                "source": {
+                  "text": "Planning Data",
+                  "url": "https://www.planning.data.gov.uk/entity/7010002192"
+                }
               }
             ]
           },
@@ -307,7 +310,7 @@
             "intersects": false
           },
           {
-            "value": "designated.SPA",
+            "value": "nature.SPA",
             "description": "Special Protection Area (SPA)",
             "intersects": false
           },
@@ -328,7 +331,10 @@
             "entities": [
               {
                 "name": "Chilterns",
-                "source": "https://www.planning.data.gov.uk/entity/1000005"
+                "source": {
+                  "text": "Planning Data",
+                  "url": "https://www.planning.data.gov.uk/entity/1000005"
+                }
               }
             ]
           },
@@ -367,7 +373,7 @@
     "proposal": {
       "projectType": [
         {
-          "value": "extend.outbuildings.studio",
+          "value": "extend.outbuilding.studio",
           "description": "Add an outbuilding - studio"
         }
       ],
@@ -1854,7 +1860,42 @@
     "source": "PlanX",
     "service": {
       "flowId": "824628b2-deeb-48b0-92b1-2ca7f3b17163",
-      "url": "https://www.editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview"
+      "url": "https://www.editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview",
+      "files": {
+        "required": [
+          {
+            "value": "photographs.proposed",
+            "description": "Photographs - proposed"
+          },
+          {
+            "value": "sitePlan.proposed",
+            "description": "Site plan - proposed"
+          },
+          {
+            "value": "elevations.proposed",
+            "description": "Elevations - proposed"
+          },
+          {
+            "value": "floorPlan.proposed",
+            "description": "Floor plan - proposed"
+          },
+          {
+            "value": "floorPlan.proposed",
+            "description": "Floor plan - proposed"
+          }
+        ],
+        "recommended": [
+          {
+            "value": "otherEvidence",
+            "description": "Other - evidence or correspondence"
+          },
+          {
+            "value": "constructionInvoice",
+            "description": "Construction invoice"
+          }
+        ],
+        "optional": []
+      }
     },
     "submittedAt": "2023-10-02t00:00:00z",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"

--- a/examples/validLawfulDevelopmentCertificateProposed.json
+++ b/examples/validLawfulDevelopmentCertificateProposed.json
@@ -183,7 +183,7 @@
             "intersects": false
           },
           {
-            "value": "designated.SPA",
+            "value": "nature.SPA",
             "description": "Special Protection Area (SPA)",
             "intersects": false
           },
@@ -1216,7 +1216,45 @@
     "source": "PlanX",
     "service": {
       "flowId": "824628b2-deeb-48b0-92b1-2ca7f3b17163",
-      "url": "https://www.editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview"
+      "url": "https://www.editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview",
+      "files": {
+        "required": [
+          {
+            "value": "roofPlan.existing",
+            "description": "Roof plan - existing"
+          },
+          {
+            "value": "sitePlan.existing",
+            "description": "Site plan - existing"
+          },
+          {
+            "value": "roofPlan.proposed",
+            "description": "Roof plan - proposed"
+          },
+          {
+            "value": "sitePlan.proposed",
+            "description": "Site plan - proposed"
+          },
+          {
+            "value": "elevations.existing",
+            "description": "Elevations - existing"
+          },
+          {
+            "value": "floorPlan.existing",
+            "description": "Floor plan - existing"
+          },
+          {
+            "value": "elevations.proposed",
+            "description": "Elevations - proposed"
+          },
+          {
+            "value": "floorPlan.proposed",
+            "description": "Floor plan - proposed"
+          }
+        ],
+        "recommended": [],
+        "optional": []
+      }
     },
     "submittedAt": "2023-10-02T00:00:00+01:00",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"

--- a/examples/validPlanningPermission.json
+++ b/examples/validPlanningPermission.json
@@ -180,7 +180,7 @@
             "intersects": false
           },
           {
-            "value": "designated.SPA",
+            "value": "nature.SPA",
             "description": "Special Protection Area (SPA)",
             "intersects": false
           },
@@ -1765,7 +1765,46 @@
     "source": "PlanX",
     "service": {
       "flowId": "01e38c5d-e701-4e44-acdc-4d6b5cc3b854",
-      "url": "https://www.editor.planx.dev/lambeth/apply-for-planning-permission/preview"
+      "url": "https://www.editor.planx.dev/lambeth/apply-for-planning-permission/preview",
+      "files": {
+        "required": [
+          {
+            "value": "roofPlan.existing",
+            "description": "Roof plan - existing"
+          },
+          {
+            "value": "roofPlan.proposed",
+            "description": "Roof plan - proposed"
+          },
+          {
+            "value": "sitePlan.existing",
+            "description": "Site plan - existing"
+          },
+          {
+            "value": "sitePlan.proposed",
+            "description": "Site plan - proposed"
+          },
+          {
+            "value": "elevations.existing",
+            "description": "Elevations - existing"
+          },
+          {
+            "value": "elevations.proposed",
+            "description": "Elevations - proposed"
+          }
+        ],
+        "recommended": [
+          {
+            "value": "floorPlan.existing",
+            "description": "Floor plan - existing"
+          },
+          {
+            "value": "floorPlan.proposed",
+            "description": "Floor plan - proposed"
+          }
+        ],
+        "optional": []
+      }
     },
     "submittedAt": "2023-10-02T00:00:00.00Z",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"

--- a/examples/validPriorApproval.json
+++ b/examples/validPriorApproval.json
@@ -131,27 +131,42 @@
               {
                 "name": "Central Activities Zone",
                 "description": "Change of use from offices to dwelling houses is restricted",
-                "source": "https://www.planning.data.gov.uk/entity/7010000942"
+                "source": {
+                  "text": "Planning Data",
+                  "url": "https://www.planning.data.gov.uk/entity/7010000942"
+                }
               },
               {
                 "name": "Central Activities Zone",
                 "description": "Demolition of commercial buildings and construction of new dwellinghouses is restricted",
-                "source": "https://www.planning.data.gov.uk/entity/7010000944"
+                "source": {
+                  "text": "Planning Data",
+                  "url": "https://www.planning.data.gov.uk/entity/7010000944"
+                }
               },
               {
                 "name": "Bankside and Borough District Town Centre",
                 "description": "Demolition of commercial buildings and construction of new dwellinghouses is restricted",
-                "source": "https://www.planning.data.gov.uk/entity/7010001042"
+                "source": {
+                  "text": "Planning Data",
+                  "url": "https://www.planning.data.gov.uk/entity/7010001042"
+                }
               },
               {
                 "name": "Central Activities Zone",
                 "description": "Change of use from Class E to residential is restricted",
-                "source": "https://www.planning.data.gov.uk/entity/7010001055"
+                "source": {
+                  "text": "Planning Data",
+                  "url": "https://www.planning.data.gov.uk/entity/7010001055"
+                }
               },
               {
                 "name": "Bankside and Borough District Town Centre",
                 "description": "Change of use from Class E to residential is restricted",
-                "source": "https://www.planning.data.gov.uk/entity/7010001153"
+                "source": {
+                  "text": "Planning Data",
+                  "url": "https://www.planning.data.gov.uk/entity/7010001153"
+                }
               }
             ]
           },
@@ -202,7 +217,7 @@
             "intersects": false
           },
           {
-            "value": "designated.SPA",
+            "value": "nature.SPA",
             "description": "Special Protection Area (SPA)",
             "intersects": false
           },
@@ -1102,7 +1117,22 @@
     "source": "PlanX",
     "service": {
       "flowId": "c6628103-c648-4663-81e1-bfa0a1a18340",
-      "url": "https://www.editor.planx.dev/southwark/apply-for-prior-approval/preview"
+      "url": "https://www.editor.planx.dev/southwark/apply-for-prior-approval/preview",
+      "files": {
+        "required": [
+          {
+            "value": "otherDrawing",
+            "description": "Other - drawing"
+          }
+        ],
+        "recommended": [
+          {
+            "value": "sitePlan.proposed",
+            "description": "Site plan - proposed"
+          }
+        ],
+        "optional": []
+      }
     },
     "submittedAt": "2023-10-02T00:00:00Z",
     "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/@next/schema.json"

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -3224,6 +3224,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Viability Appraisal",
+              "type": "string"
+            },
+            "value": {
+              "const": "viabilityAppraisal",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Visualisations",
               "type": "string"
             },


### PR DESCRIPTION
Our examples & schema are correct in `dist` & in `/examples/data` on `main`, but the _generated_ examples and schema.json on `main` can fall out of sync with CI tests still passing if you simply forget to run either of these commands manually before pushing your changes (see #131) - too easy to forget & causing confusion with consumers!

This adds `pnpm build-json-examples` & `pnpm build-schema:dev` commands to the pre-commit hook if the branch is _not_ `main`. This should keep all files on main tagged at the `@next` version, and _not_ impact the Github Actions workflow for publishing from `main` to `dist` with a correct published version number.