### PR TITLE
feat: add types for existing & proposed `Materials`

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4098,6 +4098,10 @@
           },
           "type": "array"
         },
+        "materials": {
+          "$ref": "#/definitions/Materials",
+          "description": "Details about the existing materials"
+        },
         "planning": {
           "additionalProperties": false,
           "description": "Planning constraints and policies that intersect with this site and may impact or restrict development",
@@ -4190,6 +4194,36 @@
         "titleNumber",
         "type"
       ],
+      "type": "object"
+    },
+    "Materials": {
+      "additionalProperties": false,
+      "properties": {
+        "boundary": {
+          "type": "string"
+        },
+        "door": {
+          "type": "string"
+        },
+        "lighting": {
+          "type": "string"
+        },
+        "other": {
+          "type": "string"
+        },
+        "roof": {
+          "type": "string"
+        },
+        "surface": {
+          "type": "string"
+        },
+        "wall": {
+          "type": "string"
+        },
+        "window": {
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "Metadata": {
@@ -20980,6 +21014,10 @@
         "details": {
           "$ref": "#/definitions/ProposalDetails"
         },
+        "materials": {
+          "$ref": "#/definitions/Materials",
+          "description": "Details about the proposed materials"
+        },
         "projectType": {
           "items": {
             "$ref": "#/definitions/ProjectType"
@@ -21836,6 +21874,10 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "materials": {
+          "$ref": "#/definitions/Materials",
+          "description": "Details about the existing materials"
         },
         "planning": {
           "additionalProperties": false,

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4098,15 +4098,7 @@
           "type": "object"
         },
         "details": {
-          "$id": "#PropertyDetails",
-          "additionalProperties": false,
-          "description": "Details about the property as it currently exists",
-          "properties": {
-            "materials": {
-              "$ref": "#/definitions/Materials"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/PropertyDetails"
         },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
@@ -12637,6 +12629,17 @@
         }
       ],
       "description": "Information about the site where the works will happen"
+    },
+    "PropertyDetails": {
+      "$id": "#PropertyDetails",
+      "additionalProperties": false,
+      "description": "Details about the property as it currently exists",
+      "properties": {
+        "materials": {
+          "$ref": "#/definitions/Materials"
+        }
+      },
+      "type": "object"
     },
     "PropertyType": {
       "$id": "#PropertyType",
@@ -21878,15 +21881,7 @@
           "type": "object"
         },
         "details": {
-          "$id": "#PropertyDetails",
-          "additionalProperties": false,
-          "description": "Details about the property as it currently exists",
-          "properties": {
-            "materials": {
-              "$ref": "#/definitions/Materials"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/PropertyDetails"
         },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1575,6 +1575,9 @@
           ],
           "type": "object"
         },
+        "materials": {
+          "$ref": "#/definitions/Materials"
+        },
         "new": {
           "additionalProperties": false,
           "properties": {
@@ -3414,6 +3417,9 @@
           ],
           "type": "object"
         },
+        "materials": {
+          "$ref": "#/definitions/Materials"
+        },
         "new": {
           "additionalProperties": false,
           "properties": {
@@ -4091,16 +4097,23 @@
           ],
           "type": "object"
         },
+        "details": {
+          "$id": "#PropertyDetails",
+          "additionalProperties": false,
+          "description": "Details about the property as it currently exists",
+          "properties": {
+            "materials": {
+              "$ref": "#/definitions/Materials"
+            }
+          },
+          "type": "object"
+        },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
           "type": "array"
-        },
-        "materials": {
-          "$ref": "#/definitions/Materials",
-          "description": "Details about the existing materials"
         },
         "planning": {
           "additionalProperties": false,
@@ -21014,10 +21027,6 @@
         "details": {
           "$ref": "#/definitions/ProposalDetails"
         },
-        "materials": {
-          "$ref": "#/definitions/Materials",
-          "description": "Details about the proposed materials"
-        },
         "projectType": {
           "items": {
             "$ref": "#/definitions/ProjectType"
@@ -21868,16 +21877,23 @@
           ],
           "type": "object"
         },
+        "details": {
+          "$id": "#PropertyDetails",
+          "additionalProperties": false,
+          "description": "Details about the property as it currently exists",
+          "properties": {
+            "materials": {
+              "$ref": "#/definitions/Materials"
+            }
+          },
+          "type": "object"
+        },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
           "type": "array"
-        },
-        "materials": {
-          "$ref": "#/definitions/Materials",
-          "description": "Details about the existing materials"
         },
         "planning": {
           "additionalProperties": false,

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -2,6 +2,7 @@ import {GeoJSON} from 'geojson';
 import {PlanningDesignations} from '../../enums/PlanningConstraints';
 import {PropertyTypes} from '../../enums/PropertyTypes';
 import {Area, URL} from '../../utils';
+import {Materials} from './shared';
 
 /**
  * @id #Property
@@ -59,6 +60,10 @@ export interface UKProperty {
       neighbourhood: PlanningConstraint[];
     };
   };
+  /**
+   * @description Details about the existing materials
+   */
+  materials?: Materials;
 }
 
 /**

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -60,14 +60,16 @@ export interface UKProperty {
       neighbourhood: PlanningConstraint[];
     };
   };
-  /**
-   * @id #PropertyDetails
-   * @description Details about the property as it currently exists
-   */
-  details?: {
-    materials?: Materials;
-  };
+  details?: PropertyDetails;
 }
+
+/**
+ * @id #PropertyDetails
+ * @description Details about the property as it currently exists
+ */
+export type PropertyDetails = {
+  materials?: Materials;
+};
 
 /**
  * @id #LondonProperty

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -61,9 +61,12 @@ export interface UKProperty {
     };
   };
   /**
-   * @description Details about the existing materials
+   * @id #PropertyDetails
+   * @description Details about the property as it currently exists
    */
-  materials?: Materials;
+  details?: {
+    materials?: Materials;
+  };
 }
 
 /**

--- a/types/schema/data/Proposal.ts
+++ b/types/schema/data/Proposal.ts
@@ -20,10 +20,6 @@ export interface Proposal {
   };
   date?: ProposalDates;
   details?: ProposalDetails;
-  /**
-   * @description Details about the proposed materials
-   */
-  materials?: Materials;
 }
 
 /**
@@ -53,6 +49,7 @@ export interface BaseDetails {
       dwellings?: number;
     };
   };
+  materials?: Materials;
 }
 
 /**

--- a/types/schema/data/Proposal.ts
+++ b/types/schema/data/Proposal.ts
@@ -2,6 +2,7 @@ import {GeoJSON} from 'geojson';
 import {ProjectTypes} from '../../enums/ProjectTypes';
 import {VehicleParking} from '../../enums/VehicleParking';
 import {Area, Date} from '../../utils';
+import {Materials} from './shared';
 
 /**
  * @id #Proposal
@@ -19,6 +20,10 @@ export interface Proposal {
   };
   date?: ProposalDates;
   details?: ProposalDetails;
+  /**
+   * @description Details about the proposed materials
+   */
+  materials?: Materials;
 }
 
 /**

--- a/types/schema/data/shared.ts
+++ b/types/schema/data/shared.ts
@@ -1,0 +1,10 @@
+export type Materials = {
+  boundary?: string;
+  door?: string;
+  lighting?: string;
+  roof?: string;
+  surface?: string;
+  wall?: string;
+  window?: string;
+  other?: string;
+};


### PR DESCRIPTION
See rows 150-165 in `Apply for Planning Permission (Householder)` tab https://docs.google.com/spreadsheets/d/1ePihRD37-2071Wq6t2Y7QtBt7juySWuVP6SAF6T-0vo/edit#gid=1188278375

`shared.ts` file introduced here will hold definitions that are repeated between `property` & `proposal`. Parking and others are going to be similarly organised this way soon.