### PR TITLE
fix: update example `files` urls

### DIFF
--- a/examples/data/ldcE.ts
+++ b/examples/data/ldcE.ts
@@ -1178,35 +1178,20 @@ export const validLDCE: Schema = {
   ],
   files: [
     {
-      name: 'https://api.editor.planx.dev/file/private/r34zxe3x/RoaldDahlHut.jpg',
+      name: 'https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf',
       type: [
         {
           value: 'photographs.proposed',
           description: 'Photographs - proposed',
         },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/kopklkj9/Site%20plan.pdf',
-      type: [
         {
           value: 'sitePlan.proposed',
           description: 'Site plan - proposed',
         },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/u2vjw69h/Elevations.pdf',
-      type: [
         {
           value: 'elevations.proposed',
           description: 'Elevations - proposed',
         },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/gbaur05c/Plan.pdf',
-      type: [
         {
           value: 'floorPlan.proposed',
           description: 'Floor plan - proposed',
@@ -1214,7 +1199,7 @@ export const validLDCE: Schema = {
       ],
     },
     {
-      name: 'https://api.editor.planx.dev/file/private/4vhzu4c5/Roald-Dahl-letter-one-use.pdf',
+      name: 'https://api.editor.planx.dev/file/private/vyyogkcf/correspondence.pdf',
       type: [
         {
           value: 'otherEvidence',
@@ -1224,7 +1209,7 @@ export const validLDCE: Schema = {
       description: 'Nothing really, this is just a test. ',
     },
     {
-      name: 'https://api.editor.planx.dev/file/private/uz72iu40/Test%20document.pdf',
+      name: 'https://api.editor.planx.dev/file/private/97ltnrxr/invoice.pdf',
       type: [
         {
           value: 'constructionInvoice',

--- a/examples/data/ldcP.ts
+++ b/examples/data/ldcP.ts
@@ -760,62 +760,28 @@ export const validLDCP: Schema = {
   ],
   files: [
     {
-      name: 'https://api.editor.planx.dev/file/private/ha2qdn2z/RoofPlan.pdf',
+      name: 'https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf',
       type: [
         {
           value: 'roofPlan.existing',
           description: 'Roof plan - existing',
         },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/3u00rjyw/Site%20plan.pdf',
-      type: [
-        {
-          value: 'sitePlan.existing',
-          description: 'Site plan - existing',
-        },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/g92g9w65/RoofPlan.pdf',
-      type: [
         {
           value: 'roofPlan.proposed',
           description: 'Roof plan - proposed',
         },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/i7tag96k/Site%20plan.pdf',
-      type: [
+        {
+          value: 'sitePlan.existing',
+          description: 'Site plan - existing',
+        },
         {
           value: 'sitePlan.proposed',
           description: 'Site plan - proposed',
         },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/tw50m88n/Elevations.pdf',
-      type: [
         {
           value: 'elevations.existing',
           description: 'Elevations - existing',
         },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/diahn9ft/Plan.pdf',
-      type: [
-        {
-          value: 'floorPlan.existing',
-          description: 'Floor plan - existing',
-        },
-      ],
-    },
-    {
-      name: 'https://api.editor.planx.dev/file/private/0rpf43jj/Elevations.pdf',
-      type: [
         {
           value: 'elevations.proposed',
           description: 'Elevations - proposed',
@@ -823,8 +789,12 @@ export const validLDCP: Schema = {
       ],
     },
     {
-      name: 'https://api.editor.planx.dev/file/private/iio7ok5g/Plan.pdf',
+      name: 'https://api.editor.planx.dev/file/private/311w2id6/floor_plans.pdf',
       type: [
+        {
+          value: 'floorPlan.existing',
+          description: 'Floor plan - existing',
+        },
         {
           value: 'floorPlan.proposed',
           description: 'Floor plan - proposed',

--- a/examples/data/planningPermission.ts
+++ b/examples/data/planningPermission.ts
@@ -1198,7 +1198,7 @@ export const validPlanningPermission: Schema = {
   ],
   files: [
     {
-      name: 'https://api.editor.planx.dev/file/private/vg0av01p/RoofPlan.pdf',
+      name: 'https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf',
       type: [
         {
           value: 'roofPlan.existing',
@@ -1211,7 +1211,7 @@ export const validPlanningPermission: Schema = {
       ],
     },
     {
-      name: 'https://api.editor.planx.dev/file/private/ka97yl2c/Site%20plan.pdf',
+      name: 'https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf',
       type: [
         {
           value: 'sitePlan.existing',
@@ -1224,7 +1224,7 @@ export const validPlanningPermission: Schema = {
       ],
     },
     {
-      name: 'https://api.editor.planx.dev/file/private/osprppqo/Elevations.pdf',
+      name: 'https://api.editor.planx.dev/file/private/7nrefxnn/elevations.pdf',
       type: [
         {
           value: 'elevations.existing',
@@ -1237,7 +1237,7 @@ export const validPlanningPermission: Schema = {
       ],
     },
     {
-      name: 'https://api.editor.planx.dev/file/private/cri3ziaj/Plan.pdf',
+      name: 'https://api.editor.planx.dev/file/private/311w2id6/floor_plans.pdf',
       type: [
         {
           value: 'floorPlan.existing',

--- a/examples/data/priorApproval.ts
+++ b/examples/data/priorApproval.ts
@@ -764,7 +764,7 @@ export const validPriorApproval: Schema = {
   ],
   files: [
     {
-      name: 'https://api.editor.planx.dev/file/private/vab4d0k6/Test%20document.pdf',
+      name: 'https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf',
       type: [
         {
           value: 'otherDrawing',
@@ -773,7 +773,7 @@ export const validPriorApproval: Schema = {
       ],
     },
     {
-      name: 'https://api.editor.planx.dev/file/private/es3w6dgi/Elevations.pdf',
+      name: 'https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf',
       type: [
         {
           value: 'sitePlan.proposed',

--- a/examples/validLawfulDevelopmentCertificateExisting.json
+++ b/examples/validLawfulDevelopmentCertificateExisting.json
@@ -1798,35 +1798,20 @@
   ],
   "files": [
     {
-      "name": "https://api.editor.planx.dev/file/private/r34zxe3x/RoaldDahlHut.jpg",
+      "name": "https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf",
       "type": [
         {
           "value": "photographs.proposed",
           "description": "Photographs - proposed"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/kopklkj9/Site%20plan.pdf",
-      "type": [
+        },
         {
           "value": "sitePlan.proposed",
           "description": "Site plan - proposed"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/u2vjw69h/Elevations.pdf",
-      "type": [
+        },
         {
           "value": "elevations.proposed",
           "description": "Elevations - proposed"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/gbaur05c/Plan.pdf",
-      "type": [
+        },
         {
           "value": "floorPlan.proposed",
           "description": "Floor plan - proposed"
@@ -1834,7 +1819,7 @@
       ]
     },
     {
-      "name": "https://api.editor.planx.dev/file/private/4vhzu4c5/Roald-Dahl-letter-one-use.pdf",
+      "name": "https://api.editor.planx.dev/file/private/vyyogkcf/correspondence.pdf",
       "type": [
         {
           "value": "otherEvidence",
@@ -1844,7 +1829,7 @@
       "description": "Nothing really, this is just a test. "
     },
     {
-      "name": "https://api.editor.planx.dev/file/private/uz72iu40/Test%20document.pdf",
+      "name": "https://api.editor.planx.dev/file/private/97ltnrxr/invoice.pdf",
       "type": [
         {
           "value": "constructionInvoice",

--- a/examples/validLawfulDevelopmentCertificateProposed.json
+++ b/examples/validLawfulDevelopmentCertificateProposed.json
@@ -1138,62 +1138,28 @@
   ],
   "files": [
     {
-      "name": "https://api.editor.planx.dev/file/private/ha2qdn2z/RoofPlan.pdf",
+      "name": "https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf",
       "type": [
         {
           "value": "roofPlan.existing",
           "description": "Roof plan - existing"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/3u00rjyw/Site%20plan.pdf",
-      "type": [
-        {
-          "value": "sitePlan.existing",
-          "description": "Site plan - existing"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/g92g9w65/RoofPlan.pdf",
-      "type": [
+        },
         {
           "value": "roofPlan.proposed",
           "description": "Roof plan - proposed"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/i7tag96k/Site%20plan.pdf",
-      "type": [
+        },
+        {
+          "value": "sitePlan.existing",
+          "description": "Site plan - existing"
+        },
         {
           "value": "sitePlan.proposed",
           "description": "Site plan - proposed"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/tw50m88n/Elevations.pdf",
-      "type": [
+        },
         {
           "value": "elevations.existing",
           "description": "Elevations - existing"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/diahn9ft/Plan.pdf",
-      "type": [
-        {
-          "value": "floorPlan.existing",
-          "description": "Floor plan - existing"
-        }
-      ]
-    },
-    {
-      "name": "https://api.editor.planx.dev/file/private/0rpf43jj/Elevations.pdf",
-      "type": [
+        },
         {
           "value": "elevations.proposed",
           "description": "Elevations - proposed"
@@ -1201,8 +1167,12 @@
       ]
     },
     {
-      "name": "https://api.editor.planx.dev/file/private/iio7ok5g/Plan.pdf",
+      "name": "https://api.editor.planx.dev/file/private/311w2id6/floor_plans.pdf",
       "type": [
+        {
+          "value": "floorPlan.existing",
+          "description": "Floor plan - existing"
+        },
         {
           "value": "floorPlan.proposed",
           "description": "Floor plan - proposed"

--- a/examples/validPlanningPermission.json
+++ b/examples/validPlanningPermission.json
@@ -1707,7 +1707,7 @@
   ],
   "files": [
     {
-      "name": "https://api.editor.planx.dev/file/private/vg0av01p/RoofPlan.pdf",
+      "name": "https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf",
       "type": [
         {
           "value": "roofPlan.existing",
@@ -1720,7 +1720,7 @@
       ]
     },
     {
-      "name": "https://api.editor.planx.dev/file/private/ka97yl2c/Site%20plan.pdf",
+      "name": "https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf",
       "type": [
         {
           "value": "sitePlan.existing",
@@ -1733,7 +1733,7 @@
       ]
     },
     {
-      "name": "https://api.editor.planx.dev/file/private/osprppqo/Elevations.pdf",
+      "name": "https://api.editor.planx.dev/file/private/7nrefxnn/elevations.pdf",
       "type": [
         {
           "value": "elevations.existing",
@@ -1746,7 +1746,7 @@
       ]
     },
     {
-      "name": "https://api.editor.planx.dev/file/private/cri3ziaj/Plan.pdf",
+      "name": "https://api.editor.planx.dev/file/private/311w2id6/floor_plans.pdf",
       "type": [
         {
           "value": "floorPlan.existing",

--- a/examples/validPriorApproval.json
+++ b/examples/validPriorApproval.json
@@ -1093,7 +1093,7 @@
   ],
   "files": [
     {
-      "name": "https://api.editor.planx.dev/file/private/vab4d0k6/Test%20document.pdf",
+      "name": "https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf",
       "type": [
         {
           "value": "otherDrawing",
@@ -1102,7 +1102,7 @@
       ]
     },
     {
-      "name": "https://api.editor.planx.dev/file/private/es3w6dgi/Elevations.pdf",
+      "name": "https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf",
       "type": [
         {
           "value": "sitePlan.proposed",


### PR DESCRIPTION
Some example files were hitting up against our 6 month retention period and removed from S3, therefore throwing this error when BOPS tries to download if submitted: `Error: Failed to download private file: NoSuchKey: The specified key does not exist.` (https://planx.airbrake.io/projects/329753/groups/3759175601873853255)

There's a larger piece of work to update example data more robustly, but these fresh files will make existing example payloads usable in meantime! 

