### PR TITLE
fix: missing or incorrect `ProjectTypes` values

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -11355,7 +11355,7 @@
               "type": "string"
             },
             "value": {
-              "const": "changeofUse.annexe",
+              "const": "changeOfUse.annexe",
               "type": "string"
             }
           },
@@ -13174,6 +13174,24 @@
             },
             "value": {
               "const": "not.alter.rooflight",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Do not add or change a dropped kerb",
+              "type": "string"
+            },
+            "value": {
+              "const": "not.dropKerb",
               "type": "string"
             }
           },

--- a/types/enums/ProjectTypes.ts
+++ b/types/enums/ProjectTypes.ts
@@ -196,7 +196,7 @@ export const ProjectTypes = {
   'alter.trees.tree.prune': 'Prune trees',
   'alter.trees.tree.remove': 'Remove trees',
   changeOfUse: 'Change the use of a building',
-  'changeofUse.annexe':
+  'changeOfUse.annexe':
     'Convert part of the property into a  granny flat (residential annexe)',
   'changeOfUse.caravans': 'Use a caravan or mobile home on the property',
   'changeOfUse.extension': 'Convert an extension',
@@ -306,6 +306,7 @@ export const ProjectTypes = {
   not: 'Negate a project type',
   'not.alter.replace': 'Do not add or change windows or doors',
   'not.alter.rooflight': 'Do not add or change a rooflight',
+  'not.dropKerb': 'Do not add or change a dropped kerb',
   unit: 'Change of units',
   'unit.merge': 'Convert two or more properties into one',
   'unit.subdivide': 'Convert a home or part of a home into flats',


### PR DESCRIPTION
Two `ProjectTypes` related bugs that have been raised in recent testing:
- `not` prefixed values will eventually be dropped once new SetValue functionality is implemented, but we should support them in the meantime as long as they still exist in service content
- Lambeth's testing on Friday hit the `changeOfUse.annexe` typo and I updated staging session data directly to succesfully resubmit in the interim until we have a more thorough next release