### PR TITLE
Split treeworksConsent into two separate types

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1564,11 +1564,47 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Consent to carry out works to a tree in a Conservation Area or with a Tree Preservation Order",
+              "const": "Works to trees",
               "type": "string"
             },
             "value": {
-              "const": "treeWorksConsent",
+              "const": "wtt",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Works to trees - Consent to carry out works to a tree with a Tree Preservation Order",
+              "type": "string"
+            },
+            "value": {
+              "const": "wtt.consent",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Works to trees - Notification of proposed works to a tree in a Conservation Area",
+              "type": "string"
+            },
+            "value": {
+              "const": "wtt.notice",
               "type": "string"
             }
           },

--- a/types/enums/ApplicationTypes.ts
+++ b/types/enums/ApplicationTypes.ts
@@ -112,6 +112,9 @@ export const ApplicationTypes = {
     'Outline Planning Permission - Approval of reserved matters (major)',
   'pp.outline.major.someReserved':
     'Outline Planning Permission - Consent for the principle of a project specifying some details (major)',
-  treeWorksConsent:
-    'Consent to carry out works to a tree in a Conservation Area or with a Tree Preservation Order',
+  wtt: 'Works to trees',
+  'wtt.consent':
+    'Works to trees - Consent to carry out works to a tree with a Tree Preservation Order',
+  'wtt.notice':
+    'Works to trees - Notification of proposed works to a tree in a Conservation Area',
 };


### PR DESCRIPTION
Despite the [standard form][1] combining both types of tree works they follow different workflows - trees with a Tree Preservation Order (TPO) is an [application for consent][2] whereas trees in a Conservation Area (CA) is a [notification of intended works][3].

The process for trees with a TPO takes eight weeks and the process for trees in a CA is six weeks. Trees in a conservation area with an existing TPO follow the standard procedure.

[1]: https://assets.publishing.service.gov.uk/media/5b06c81de5274a1c5490ce6f/Form031_england_en_revised__2_.pdf
[2]: https://www.gov.uk/guidance/tree-preservation-orders-and-trees-in-conservation-areas#making-applications-tpo
[3]: https://www.gov.uk/guidance/tree-preservation-orders-and-trees-in-conservation-areas#Protecting-trees-in-conservation-areas