### PR TITLE
feat: add `ProjectTypes` support by Listed Building Consent journeys

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -8777,6 +8777,222 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Change the material of a fence, wall or gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.boundary",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of chimneys",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.chimney",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of external doors",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.externalDoors",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of external walls",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.externalWalls",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of floors",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.floors",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of vehicle access or hardstanding",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.hardstanding",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of internal doors",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.internalDoors",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of internal walls",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.internalWalls",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of something else",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.other",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of rainwater goods",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.rainwaterGoods",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of roof coverings",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.roofCovering",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material of windows",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.changeOfMaterials.windows",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Change chimneys",
               "type": "string"
             },
@@ -11621,11 +11837,83 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Demolish a building",
+              "const": "Total demolition of a building",
               "type": "string"
             },
             "value": {
               "const": "demolish.full",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Demolish internal walls",
+              "type": "string"
+            },
+            "value": {
+              "const": "demolish.internal",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Demolish a listed building",
+              "type": "string"
+            },
+            "value": {
+              "const": "demolish.listed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Total demolition of a isted building",
+              "type": "string"
+            },
+            "value": {
+              "const": "demolish.listed.full",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Demolish part of a listed building",
+              "type": "string"
+            },
+            "value": {
+              "const": "demolish.listed.part",
               "type": "string"
             }
           },
@@ -11644,6 +11932,42 @@
             },
             "value": {
               "const": "demolish.outbuilding",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Total demolition of an outbuilding (such as a garage or barn)",
+              "type": "string"
+            },
+            "value": {
+              "const": "demolish.outbuilding.full",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Demolish part of an outbuilding (such as a garage or barn)",
+              "type": "string"
+            },
+            "value": {
+              "const": "demolish.outbuilding.part",
               "type": "string"
             }
           },
@@ -13192,6 +13516,60 @@
             },
             "value": {
               "const": "not.dropKerb",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repairs",
+              "type": "string"
+            },
+            "value": {
+              "const": "repair",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair the historic fabric",
+              "type": "string"
+            },
+            "value": {
+              "const": "repair.historicFabric",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Other project type",
+              "type": "string"
+            },
+            "value": {
+              "const": "other",
               "type": "string"
             }
           },

--- a/types/enums/ProjectTypes.ts
+++ b/types/enums/ProjectTypes.ts
@@ -24,6 +24,26 @@ export const ProjectTypes = {
   'alter.boundary.replace.gate': 'Replace a gate',
   'alter.boundary.replace.wall': 'Replace a wall',
   'alter.cables': 'Install underground cables',
+  'alter.changeOfMaterials.boundary':
+    'Change the material of a fence, wall or gate',
+  'alter.changeOfMaterials.chimney': 'Change the material of chimneys',
+  'alter.changeOfMaterials.externalDoors':
+    'Change the material of external doors',
+  'alter.changeOfMaterials.externalWalls':
+    'Change the material of external walls',
+  'alter.changeOfMaterials.floors': 'Change the material of floors',
+  'alter.changeOfMaterials.hardstanding':
+    'Change the material of vehicle access or hardstanding',
+  'alter.changeOfMaterials.internalDoors':
+    'Change the material of internal doors',
+  'alter.changeOfMaterials.internalWalls':
+    'Change the material of internal walls',
+  'alter.changeOfMaterials.other': 'Change the material of something else',
+  'alter.changeOfMaterials.rainwaterGoods':
+    'Change the material of rainwater goods',
+  'alter.changeOfMaterials.roofCovering':
+    'Change the material of roof coverings',
+  'alter.changeOfMaterials.windows': 'Change the material of windows',
   'alter.chimneys': 'Change chimneys',
   'alter.chimneys.add': 'Add a chimney',
   'alter.chimneys.replace': 'Replace a chimney',
@@ -213,8 +233,16 @@ export const ProjectTypes = {
   'changeOfUse.workFromHome': 'Work from home',
   demolish: 'Demolish a building',
   'demolish.boundary': 'Demolish a fence, gate or boundary wall',
-  'demolish.full': 'Demolish a building',
+  'demolish.full': 'Total demolition of a building',
+  'demolish.internal': 'Demolish internal walls',
+  'demolish.listed': 'Demolish a listed building',
+  'demolish.listed.full': 'Total demolition of a isted building',
+  'demolish.listed.part': 'Demolish part of a listed building',
   'demolish.outbuilding': 'Demolish an outbuilding (such as a garage or barn)',
+  'demolish.outbuilding.full':
+    'Total demolition of an outbuilding (such as a garage or barn)',
+  'demolish.outbuilding.part':
+    'Demolish part of an outbuilding (such as a garage or barn)',
   'demolish.part': 'Demolish part of a building (such as an extension)',
   'demolish.part.conservatory': 'Demolish part of a conservatory',
   'demolish.replace': 'Demolish a building and build homes in its place',
@@ -307,6 +335,9 @@ export const ProjectTypes = {
   'not.alter.replace': 'Do not add or change windows or doors',
   'not.alter.rooflight': 'Do not add or change a rooflight',
   'not.dropKerb': 'Do not add or change a dropped kerb',
+  repair: 'Repairs',
+  'repair.historicFabric': 'Repair the historic fabric',
+  other: 'Other project type',
   unit: 'Change of units',
   'unit.merge': 'Convert two or more properties into one',
   'unit.subdivide': 'Convert a home or part of a home into flats',


### PR DESCRIPTION
Synced from:
- Planx service content https://editor.planx.uk/opensystemslab/listed-building-consent-more-information
- "Project Types" tab here https://docs.google.com/spreadsheets/d/1ePihRD37-2071Wq6t2Y7QtBt7juySWuVP6SAF6T-0vo/edit#gid=389104115