### PR TITLE
chore: Typo in `ProtectedSpaceDesignation`

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4136,7 +4136,7 @@
                     "type": "string"
                   },
                   "designation": {
-                    "$ref": "#/definitions/ProtectedSpaceDesgination"
+                    "$ref": "#/definitions/ProtectedSpaceDesignation"
                   },
                   "impact": {
                     "enum": [
@@ -21675,7 +21675,7 @@
       ],
       "type": "object"
     },
-    "ProtectedSpaceDesgination": {
+    "ProtectedSpaceDesignation": {
       "$id": "#ProtectedSpaceDesignation",
       "anyOf": [
         {

--- a/types/schema/data/Proposal.ts
+++ b/types/schema/data/Proposal.ts
@@ -102,7 +102,7 @@ export interface LondonProposal extends BaseProposal {
     protectedSpaces?: {
       impact: 'loss' | 'gain' | 'change';
       description: string;
-      designation: ProtectedSpaceDesgination;
+      designation: ProtectedSpaceDesignation;
       access: 'restricted' | 'unrestricted';
       area: {hectares: number};
     }[];
@@ -221,5 +221,5 @@ type ProtectedSpaceDesignationMap = {
  * @id #ProtectedSpaceDesignation
  * @description Designations of natural protected spaces
  */
-export type ProtectedSpaceDesgination =
+export type ProtectedSpaceDesignation =
   ProtectedSpaceDesignationMap[keyof ProtectedSpaceDesignationMap];


### PR DESCRIPTION
Quick fix! I think this is technically a breaking change if anybody is using the types from this repo, but not the schema itself.