### PR TITLE
feat: add breakdown by planning fee catogories to `ApplicationFee` & `FeeExplanation` 

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -293,6 +293,7 @@
         },
         "category": {
           "additionalProperties": false,
+          "description": "Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2",
           "properties": {
             "eight": {
               "type": "number"
@@ -2096,7 +2097,7 @@
     "FeeExplanation": {
       "$id": "#FeeExplanation",
       "additionalProperties": false,
-      "description": "An explanation, including policy references, of the calculated and payable fees associated with this application",
+      "description": "An explanation, including policy references, of the fees associated with this application",
       "properties": {
         "calculated": {
           "items": {
@@ -2106,6 +2107,7 @@
         },
         "category": {
           "additionalProperties": false,
+          "description": "Breakdown of calculated fee by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2",
           "properties": {
             "eight": {
               "items": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -288,7 +288,83 @@
       "description": "The costs associated with this application",
       "properties": {
         "calculated": {
+          "description": "Total calculated fee in GBP",
           "type": "number"
+        },
+        "category": {
+          "additionalProperties": false,
+          "properties": {
+            "eight": {
+              "type": "number"
+            },
+            "eleven": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "one"
+              ],
+              "type": "object"
+            },
+            "five": {
+              "type": "number"
+            },
+            "fiveToThirteen": {
+              "type": "number"
+            },
+            "four": {
+              "type": "number"
+            },
+            "fourteen": {
+              "type": "number"
+            },
+            "nine": {
+              "type": "number"
+            },
+            "one": {
+              "type": "number"
+            },
+            "oneToFour": {
+              "type": "number"
+            },
+            "oneToThirteen": {
+              "type": "number"
+            },
+            "sixAndSeven": {
+              "type": "number"
+            },
+            "ten": {
+              "type": "number"
+            },
+            "thirteen": {
+              "type": "number"
+            },
+            "three": {
+              "type": "number"
+            },
+            "twelve": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "type": "number"
+                },
+                "two": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "two": {
+              "type": "number"
+            },
+            "twoToFour": {
+              "type": "number"
+            }
+          },
+          "type": "object"
         },
         "exemption": {
           "additionalProperties": false,
@@ -307,6 +383,7 @@
           "type": "object"
         },
         "payable": {
+          "description": "Total payable fee after any exemptions or reductions in GBP",
           "type": "number"
         },
         "reduction": {
@@ -2026,6 +2103,135 @@
             "$ref": "#/definitions/CalculateMetadata"
           },
           "type": "array"
+        },
+        "category": {
+          "additionalProperties": false,
+          "properties": {
+            "eight": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "eleven": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "items": {
+                    "$ref": "#/definitions/CalculateMetadata"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "one"
+              ],
+              "type": "object"
+            },
+            "five": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "fiveToThirteen": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "four": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "fourteen": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "nine": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "one": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "oneToFour": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "oneToThirteen": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "sixAndSeven": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "ten": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "thirteen": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "three": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "twelve": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "items": {
+                    "$ref": "#/definitions/CalculateMetadata"
+                  },
+                  "type": "array"
+                },
+                "two": {
+                  "items": {
+                    "$ref": "#/definitions/CalculateMetadata"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "two": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "twoToFour": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
         },
         "payable": {
           "items": {

--- a/types/schema/Metadata.ts
+++ b/types/schema/Metadata.ts
@@ -55,11 +55,14 @@ export interface CalculateMetadata {
 
 /**
  * @id #FeeExplanation
- * @description An explanation, including policy references, of the calculated and payable fees associated with this application
+ * @description An explanation, including policy references, of the fees associated with this application
  */
 export interface FeeExplanation {
   calculated: CalculateMetadata[];
   payable: CalculateMetadata[];
+  /**
+   * @description Breakdown of calculated fee by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2
+   */
   category?: {
     one?: CalculateMetadata[];
     oneToFour?: CalculateMetadata[];

--- a/types/schema/Metadata.ts
+++ b/types/schema/Metadata.ts
@@ -60,6 +60,30 @@ export interface CalculateMetadata {
 export interface FeeExplanation {
   calculated: CalculateMetadata[];
   payable: CalculateMetadata[];
+  category?: {
+    one?: CalculateMetadata[];
+    oneToFour?: CalculateMetadata[];
+    oneToThirteen?: CalculateMetadata[];
+    two?: CalculateMetadata[];
+    twoToFour?: CalculateMetadata[];
+    three?: CalculateMetadata[];
+    four?: CalculateMetadata[];
+    five?: CalculateMetadata[];
+    fiveToThirteen?: CalculateMetadata[];
+    sixAndSeven?: CalculateMetadata[];
+    eight?: CalculateMetadata[];
+    nine?: CalculateMetadata[];
+    ten?: CalculateMetadata[];
+    eleven?: {
+      one: CalculateMetadata[];
+    };
+    twelve?: {
+      one?: CalculateMetadata[];
+      two?: CalculateMetadata[];
+    };
+    thirteen?: CalculateMetadata[];
+    fourteen?: CalculateMetadata[];
+  };
 }
 
 /**

--- a/types/schema/data/Application.ts
+++ b/types/schema/data/Application.ts
@@ -38,7 +38,7 @@ export interface ApplicationFee {
    */
   payable: number;
   /**
-   * @descrtion Breakdown of calculated fee by UK Planning Fee category (** TODO add docs **)
+   * @description Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2
    */
   category?: {
     one?: number;

--- a/types/schema/data/Application.ts
+++ b/types/schema/data/Application.ts
@@ -29,8 +29,41 @@ export interface LondonApplication extends BaseApplication {
  * @description The costs associated with this application
  */
 export interface ApplicationFee {
+  /**
+   * @description Total calculated fee in GBP
+   */
   calculated: number;
+  /**
+   * @description Total payable fee after any exemptions or reductions in GBP
+   */
   payable: number;
+  /**
+   * @descrtion Breakdown of calculated fee by UK Planning Fee category (** TODO add docs **)
+   */
+  category?: {
+    one?: number;
+    oneToFour?: number;
+    oneToThirteen?: number;
+    two?: number;
+    twoToFour?: number;
+    three?: number;
+    four?: number;
+    five?: number;
+    fiveToThirteen?: number;
+    sixAndSeven?: number;
+    eight?: number;
+    nine?: number;
+    ten?: number;
+    eleven?: {
+      one: number;
+    };
+    twelve?: {
+      one?: number;
+      two?: number;
+    };
+    thirteen?: number;
+    fourteen?: number;
+  };
   exemption: {
     disability: boolean; // @todo add application.fee.exemption.disability.reason
     resubmission: boolean; // @todo add application.resubmission.original.applicationReference & application.resubmission.originalReference.appeal


### PR DESCRIPTION
Based on service changes queued up here https://editor.planx.uk/opensystemslab/fee-calculator-new