### PR TITLE
fix: all `LondonProperty` fields should be optional besides "region"

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -4331,11 +4331,9 @@
         }
       },
       "required": [
-        "EPC",
         "address",
         "localAuthorityDistrict",
         "region",
-        "titleNumber",
         "type"
       ],
       "type": "object"

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -69,14 +69,14 @@ export interface UKProperty {
  */
 export interface LondonProperty extends UKProperty {
   region: Extract<UKRegion, 'London'>;
-  titleNumber: {
+  titleNumber?: {
     known: 'Yes' | 'No';
     number?: string;
   };
   /**
    * @title Energy Performance Certificate
    */
-  EPC: {
+  EPC?: {
     known:
       | 'Yes'
       | 'Yes, but only some of the properties have one'


### PR DESCRIPTION
Because the Greater London Authority (aka `london-data-hub` service) reporting requirements don't apply consistently to all application types - eg Listed Building Consent applicants will _not_ be asked about their property's title number or EPC status.

See thread https://opensystemslab.slack.com/archives/C5Q59R3HB/p1714492246639809