### PR TITLE
feat: add `ApplicationFeeNotApplicable` union type to indicate when no costs apply

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -430,6 +430,21 @@
       ],
       "type": "object"
     },
+    "ApplicationFeeNotApplicable": {
+      "$id": "#ApplicationFeeNotApplicable",
+      "additionalProperties": false,
+      "description": "An indicator that an application fee does not apply to this application type or journey",
+      "properties": {
+        "notApplicable": {
+          "const": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "notApplicable"
+      ],
+      "type": "object"
+    },
     "ApplicationType": {
       "$id": "#ApplicationType",
       "anyOf": [
@@ -1835,7 +1850,14 @@
           "$ref": "#/definitions/ApplicationDeclaration"
         },
         "fee": {
-          "$ref": "#/definitions/ApplicationFee"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApplicationFee"
+            },
+            {
+              "$ref": "#/definitions/ApplicationFeeNotApplicable"
+            }
+          ]
         },
         "preApp": {
           "$ref": "#/definitions/PreApplication"
@@ -2247,6 +2269,21 @@
       "required": [
         "calculated",
         "payable"
+      ],
+      "type": "object"
+    },
+    "FeeExplanationNotApplicable": {
+      "$id": "#FeeExplanationNotApplicable",
+      "additionalProperties": false,
+      "description": "An indicator that an application fee does not apply to this application type or journey, therefore there is not an explanation of how it was calculated",
+      "properties": {
+        "notApplicable": {
+          "const": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "notApplicable"
       ],
       "type": "object"
     },
@@ -4034,7 +4071,14 @@
           "$ref": "#/definitions/ApplicationDeclaration"
         },
         "fee": {
-          "$ref": "#/definitions/ApplicationFee"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ApplicationFee"
+            },
+            {
+              "$ref": "#/definitions/ApplicationFeeNotApplicable"
+            }
+          ]
         },
         "leadDeveloper": {
           "$ref": "#/definitions/LeadDeveloper"
@@ -5497,7 +5541,14 @@
           "additionalProperties": false,
           "properties": {
             "fee": {
-              "$ref": "#/definitions/FeeExplanation"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FeeExplanation"
+                },
+                {
+                  "$ref": "#/definitions/FeeExplanationNotApplicable"
+                }
+              ]
             },
             "files": {
               "$ref": "#/definitions/RequestedFiles"

--- a/types/schema/Metadata.ts
+++ b/types/schema/Metadata.ts
@@ -54,6 +54,14 @@ export interface CalculateMetadata {
 }
 
 /**
+ * @id #FeeExplanationNotApplicable
+ * @description An indicator that an application fee does not apply to this application type or journey, therefore there is not an explanation of how it was calculated
+ */
+export interface FeeExplanationNotApplicable {
+  notApplicable: true;
+}
+
+/**
  * @id #FeeExplanation
  * @description An explanation, including policy references, of the fees associated with this application
  */
@@ -99,6 +107,6 @@ export interface PlanXMetadata extends BaseMetadata {
     flowId: UUID;
     url: URL;
     files: RequestedFiles;
-    fee: FeeExplanation;
+    fee: FeeExplanation | FeeExplanationNotApplicable;
   };
 }

--- a/types/schema/data/Application.ts
+++ b/types/schema/data/Application.ts
@@ -9,7 +9,7 @@ export type Application = BaseApplication | LondonApplication;
 
 export interface BaseApplication {
   type: ApplicationType;
-  fee: ApplicationFee;
+  fee: ApplicationFee | ApplicationFeeNotApplicable;
   declaration: ApplicationDeclaration;
   preApp?: PreApplication;
   CIL?: CommunityInfrastructureLevy;
@@ -22,6 +22,14 @@ export interface BaseApplication {
 export interface LondonApplication extends BaseApplication {
   vacantBuildingCredit?: boolean;
   leadDeveloper?: LeadDeveloper;
+}
+
+/**
+ * @id #ApplicationFeeNotApplicable
+ * @description An indicator that an application fee does not apply to this application type or journey
+ */
+export interface ApplicationFeeNotApplicable {
+  notApplicable: true;
 }
 
 /**


### PR DESCRIPTION
For example, Listed Building Consent applications will not have fee, and therefore applicants also won't answer questions related to exemptions or reductions. Without this, we'd require the payload displays fee = 0 and `false` exemptions/reductions which isn't entirely accurate since those questions were never encountered.

A future improvement would be to scope / connect this type directly to the applicable `ApplicationTypes` - but let's introduce more generally at first. 