### PR TITLE
fix: `Ownership` should include `interest` plus updated example payloads

### DIFF
--- a/examples/data/ldcE.ts
+++ b/examples/data/ldcE.ts
@@ -54,22 +54,21 @@ export const validLDCE: Schema = {
       siteContact: {
         role: 'applicant',
       },
-      interest: 'owner.co',
       ownership: {
-        certificate: 'b',
-        noticeGiven: true,
+        interest: 'occupier',
         owners: [
           {
+            interest: 'owner',
             name: 'Matilda Wormwood',
             address: {
               town: 'Reading',
               line1: '9, Library Way',
               line2: '',
               county: '',
-              country: '',
+              country: 'UK',
               postcode: 'L1T3R8Y',
             },
-            noticeDate: '1988-04-01',
+            noticeGiven: true,
           },
         ],
       },

--- a/examples/data/ldcP.ts
+++ b/examples/data/ldcP.ts
@@ -51,9 +51,8 @@ export const validLDCP: Schema = {
       siteContact: {
         role: 'applicant',
       },
-      interest: 'owner.sole',
       ownership: {
-        certificate: 'a',
+        interest: 'owner',
       },
     },
     property: {

--- a/examples/data/listedBuildingConsent.ts
+++ b/examples/data/listedBuildingConsent.ts
@@ -29,8 +29,8 @@ export const validListedBuildingConsent: Schema = {
         email: 'gonzo@muppets.org',
         phone: '987654321',
       },
-      interest: 'owner.sole',
       ownership: {
+        interest: 'owner.sole',
         certificate: 'b',
         noticeGiven: true,
         agriculturalTenants: true,

--- a/examples/data/planningPermission.ts
+++ b/examples/data/planningPermission.ts
@@ -54,9 +54,13 @@ export const validPlanningPermission: Schema = {
       siteContact: {
         role: 'proxy',
       },
-      interest: 'owner.sole',
       ownership: {
+        interest: 'owner.sole',
         certificate: 'a',
+        agriculturalTenants: false,
+        declaration: {
+          accurate: true,
+        },
       },
       agent: {
         name: {

--- a/examples/validLawfulDevelopmentCertificateExisting.json
+++ b/examples/validLawfulDevelopmentCertificateExisting.json
@@ -50,22 +50,21 @@
       "siteContact": {
         "role": "applicant"
       },
-      "interest": "owner.co",
       "ownership": {
-        "certificate": "b",
-        "noticeGiven": true,
+        "interest": "occupier",
         "owners": [
           {
+            "interest": "owner",
             "name": "Matilda Wormwood",
             "address": {
               "town": "Reading",
               "line1": "9, Library Way",
               "line2": "",
               "county": "",
-              "country": "",
+              "country": "UK",
               "postcode": "L1T3R8Y"
             },
-            "noticeDate": "1988-04-01"
+            "noticeGiven": true
           }
         ]
       },

--- a/examples/validLawfulDevelopmentCertificateProposed.json
+++ b/examples/validLawfulDevelopmentCertificateProposed.json
@@ -47,9 +47,8 @@
       "siteContact": {
         "role": "applicant"
       },
-      "interest": "owner.sole",
       "ownership": {
-        "certificate": "a"
+        "interest": "owner"
       }
     },
     "property": {

--- a/examples/validListedBuildingConsent.json
+++ b/examples/validListedBuildingConsent.json
@@ -25,8 +25,8 @@
         "email": "gonzo@muppets.org",
         "phone": "987654321"
       },
-      "interest": "owner.sole",
       "ownership": {
+        "interest": "owner.sole",
         "certificate": "b",
         "noticeGiven": true,
         "agriculturalTenants": true,

--- a/examples/validPlanningPermission.json
+++ b/examples/validPlanningPermission.json
@@ -50,9 +50,13 @@
       "siteContact": {
         "role": "proxy"
       },
-      "interest": "owner.sole",
       "ownership": {
-        "certificate": "a"
+        "interest": "owner.sole",
+        "certificate": "a",
+        "agriculturalTenants": false,
+        "declaration": {
+          "accurate": true
+        }
       },
       "agent": {
         "name": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -118,17 +118,6 @@
         "email": {
           "$ref": "#/definitions/Email"
         },
-        "interest": {
-          "enum": [
-            "owner",
-            "owner.sole",
-            "owner.co",
-            "tenant",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
-        },
         "name": {
           "additionalProperties": false,
           "properties": {
@@ -1773,17 +1762,6 @@
         },
         "email": {
           "$ref": "#/definitions/Email"
-        },
-        "interest": {
-          "enum": [
-            "owner",
-            "owner.sole",
-            "owner.co",
-            "tenant",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
         },
         "name": {
           "additionalProperties": false,
@@ -5420,6 +5398,7 @@
           "description": "Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice",
           "properties": {
             "accurate": {
+              "const": true,
               "type": "boolean"
             }
           },
@@ -5427,6 +5406,17 @@
             "accurate"
           ],
           "type": "object"
+        },
+        "interest": {
+          "enum": [
+            "owner",
+            "owner.sole",
+            "owner.co",
+            "tenant",
+            "occupier",
+            "other"
+          ],
+          "type": "string"
         },
         "noticeGiven": {
           "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
@@ -5451,11 +5441,8 @@
           ],
           "type": "object"
         },
-        "noticeReason": {
-          "type": "string"
-        },
         "owners": {
-          "description": "Names and addresses of all known owners and agricultural tenants",
+          "description": "Names and addresses of all known owners and agricultural tenants, including date of notice or reason requisite notice has not been given, if applicable",
           "items": {
             "additionalProperties": false,
             "properties": {
@@ -5469,11 +5456,26 @@
                   }
                 ]
               },
+              "interest": {
+                "enum": [
+                  "owner",
+                  "tenant",
+                  "occupier",
+                  "other"
+                ],
+                "type": "string"
+              },
               "name": {
+                "type": "string"
+              },
+              "noNoticeReason": {
                 "type": "string"
               },
               "noticeDate": {
                 "$ref": "#/definitions/Date"
+              },
+              "noticeGiven": {
+                "type": "boolean"
               }
             },
             "required": [
@@ -5494,9 +5496,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "certificate"
-      ],
       "type": "object"
     },
     "PlanXMetadata": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -5375,6 +5375,135 @@
       ],
       "description": "Types of natural open spaces"
     },
+    "Owners": {
+      "$id": "#Owners",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OwnersNoticeGiven"
+        },
+        {
+          "$ref": "#/definitions/OwnersNoNoticeGiven"
+        },
+        {
+          "$ref": "#/definitions/OwnersNoticeDate"
+        }
+      ],
+      "description": "Names and addresses of all known owners and agricultural tenants, including confirmation or date of notice, or reason requisite notice has not been given if applicable"
+    },
+    "OwnersNoNoticeGiven": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Address"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "interest": {
+          "enum": [
+            "owner",
+            "tenant",
+            "occupier",
+            "other"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "noNoticeReason": {
+          "type": "string"
+        },
+        "noticeGiven": {
+          "const": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "address",
+        "name",
+        "noNoticeReason",
+        "noticeGiven"
+      ],
+      "type": "object"
+    },
+    "OwnersNoticeDate": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Address"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "interest": {
+          "enum": [
+            "owner",
+            "tenant",
+            "occupier",
+            "other"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "noticeDate": {
+          "$ref": "#/definitions/Date"
+        }
+      },
+      "required": [
+        "address",
+        "name",
+        "noticeDate"
+      ],
+      "type": "object"
+    },
+    "OwnersNoticeGiven": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Address"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "interest": {
+          "enum": [
+            "owner",
+            "tenant",
+            "occupier",
+            "other"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "noticeGiven": {
+          "const": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "address",
+        "name",
+        "noticeGiven"
+      ],
+      "type": "object"
+    },
     "Ownership": {
       "$id": "#Ownership",
       "additionalProperties": false,
@@ -5442,47 +5571,8 @@
           "type": "object"
         },
         "owners": {
-          "description": "Names and addresses of all known owners and agricultural tenants, including date of notice or reason requisite notice has not been given, if applicable",
           "items": {
-            "additionalProperties": false,
-            "properties": {
-              "address": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Address"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              },
-              "interest": {
-                "enum": [
-                  "owner",
-                  "tenant",
-                  "occupier",
-                  "other"
-                ],
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "noNoticeReason": {
-                "type": "string"
-              },
-              "noticeDate": {
-                "$ref": "#/definitions/Date"
-              },
-              "noticeGiven": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "name",
-              "address"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/Owners"
           },
           "type": "array"
         },

--- a/types/schema/data/Applicant.ts
+++ b/types/schema/data/Applicant.ts
@@ -63,23 +63,40 @@ export interface Ownership {
    * @description Do you know the names and addresses of all owners and agricultural tenants?
    */
   ownersKnown?: 'all' | 'some' | 'none';
-  /**
-   * @description Names and addresses of all known owners and agricultural tenants, including date of notice or reason requisite notice has not been given, if applicable
-   */
-  owners?: {
-    interest?: 'owner' | 'tenant' | 'occupier' | 'other';
-    name: string;
-    address: Address | string;
-    noticeGiven?: boolean;
-    noticeDate?: Date;
-    noNoticeReason?: string;
-  }[];
+  owners?: Owners[];
   /**
    * @description Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice
    */
   declaration?: {
     accurate: true;
   };
+}
+
+/**
+ * @id #Owners
+ * @description Names and addresses of all known owners and agricultural tenants, including confirmation or date of notice, or reason requisite notice has not been given if applicable
+ */
+export type Owners = OwnersNoticeGiven | OwnersNoNoticeGiven | OwnersNoticeDate;
+
+export interface BaseOwners {
+  name: string;
+  address: Address | string;
+  interest?: 'owner' | 'tenant' | 'occupier' | 'other';
+}
+
+// LDC requires `noticeGiven`, and `noNoticeReason` if false
+export interface OwnersNoticeGiven extends BaseOwners {
+  noticeGiven: true;
+}
+
+export interface OwnersNoNoticeGiven extends BaseOwners {
+  noticeGiven: false;
+  noNoticeReason: string;
+}
+
+// PP & LBC require `noticeDate`
+export interface OwnersNoticeDate extends BaseOwners {
+  noticeDate: Date;
 }
 
 /**

--- a/types/schema/data/Applicant.ts
+++ b/types/schema/data/Applicant.ts
@@ -26,13 +26,6 @@ export interface BaseApplicant {
     name: string;
   };
   address: UserAddress;
-  interest?:
-    | 'owner'
-    | 'owner.sole'
-    | 'owner.co'
-    | 'tenant'
-    | 'occupier'
-    | 'other';
   ownership?: Ownership;
   siteContact: SiteContact;
 }
@@ -42,7 +35,14 @@ export interface BaseApplicant {
  * @description Information about the ownership certificate and property owners, if different than the applicant
  */
 export interface Ownership {
-  certificate: 'a' | 'b' | 'c' | 'd';
+  interest?:
+    | 'owner'
+    | 'owner.sole'
+    | 'owner.co'
+    | 'tenant'
+    | 'occupier'
+    | 'other';
+  certificate?: 'a' | 'b' | 'c' | 'd';
   /**
    * @description Does the land have any agricultural tenants?
    */
@@ -51,10 +51,6 @@ export interface Ownership {
    * @description Has requisite notice been given to all the known owners and agricultural tenants?
    */
   noticeGiven?: boolean;
-  /**
-   * @descrpition Reason requisite notice has not been given, if applicable
-   */
-  noticeReason?: string;
   /**
    * @description Has a notice of the application been published in a newspaper circulating in the area where the land is situated?
    */
@@ -68,18 +64,21 @@ export interface Ownership {
    */
   ownersKnown?: 'all' | 'some' | 'none';
   /**
-   * @description Names and addresses of all known owners and agricultural tenants
+   * @description Names and addresses of all known owners and agricultural tenants, including date of notice or reason requisite notice has not been given, if applicable
    */
   owners?: {
+    interest?: 'owner' | 'tenant' | 'occupier' | 'other';
     name: string;
     address: Address | string;
+    noticeGiven?: boolean;
     noticeDate?: Date;
+    noNoticeReason?: string;
   }[];
   /**
    * @description Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice
    */
   declaration?: {
-    accurate: boolean;
+    accurate: true;
   };
 }
 


### PR DESCRIPTION
Based on feedback from August about recent service changes to how Planx collects ownership info.

- Moves `data.applicant.interest` &rarr; `data.applicant.ownership.interest` for more meaningful heirarchy
- Updates example payloads to reflect changes to ownership service https://editor.planx.uk/opensystemslab/ownership
  - LDCs no longer set `certificate`
  - LDCs no longer report the `noticeDate` for individual owners, but simply if `noticeGiven` (boolean) and, if false,  `noNoticeReason` (string)
  - Planning Permission & LBC assign a certificate and ask more detailed questions about agricultural tenants, publishing of notice, and a declaration
  
![image (8)](https://github.com/theopensystemslab/digital-planning-data-schemas/assets/5132349/d2123f94-4ae0-4d7f-a328-0765866eb5c6)