### PR TITLE
fix: stash pnpm lockfile in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Checkout Dist Branch
         if: steps.version_check.outputs.changed == 'true'
         run: |
+          git stash -- pnpm-lock.yaml
           git fetch origin dist
           git checkout -b dist origin/dist
 


### PR DESCRIPTION
Hoping this fixes error on latest action run https://github.com/theopensystemslab/digital-planning-data-schemas/actions/runs/8983467713/job/24673409957

Package JSON & lockfile don't need to be published to `dist` branch anyways, so should be okay?