### PR TITLE
Revert "fix: stash pnpm lockfile in publish workflow"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Checkout Dist Branch
         if: steps.version_check.outputs.changed == 'true'
         run: |
-          git stash -- pnpm-lock.yaml
           git fetch origin dist
           git checkout -b dist origin/dist
 


### PR DESCRIPTION
Reverts theopensystemslab/digital-planning-data-schemas#169

This fixed v0.6.0 release - but hoping we don't actually need this line going forward so going to revert ! 

Can always repeat if we see again.