### PR TITLE
feat: support files submitted as "data"

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -462,6 +462,42 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Consent to make small (minor material) changes to a project with planning permission",
+              "type": "string"
+            },
+            "value": {
+              "const": "amendment.minorMaterial",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Consent to make small (non-material) changes to a project with planning permission",
+              "type": "string"
+            },
+            "value": {
+              "const": "amendment.nonMaterial",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Consent to move and dispose of hazardous substances",
               "type": "string"
             },
@@ -593,24 +629,6 @@
             },
             "value": {
               "const": "listed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Consent to make small changes to a project with Planning Permission",
-              "type": "string"
-            },
-            "value": {
-              "const": "nonMaterialAmendment",
               "type": "string"
             }
           },
@@ -1858,21 +1876,8 @@
       "additionalProperties": false,
       "properties": {
         "boundary": {
-          "additionalProperties": false,
-          "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary",
-          "properties": {
-            "area": {
-              "$ref": "#/definitions/Area"
-            },
-            "site": {
-              "$ref": "#/definitions/GeoJSON"
-            }
-          },
-          "required": [
-            "site",
-            "area"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/GeoBoundary",
+          "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary"
         },
         "date": {
           "$ref": "#/definitions/ProposalDates"
@@ -1996,6 +2001,30 @@
       "format": "date-time",
       "pattern": "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$",
       "type": "string"
+    },
+    "DesignAndAccessStatement": {
+      "additionalProperties": false,
+      "properties": {
+        "accessAndLayout": {
+          "type": "string"
+        },
+        "landscapingChanges": {
+          "type": "string"
+        },
+        "projectDescription": {
+          "type": "string"
+        },
+        "propertyDescription": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "propertyDescription",
+        "projectDescription",
+        "accessAndLayout",
+        "landscapingChanges"
+      ],
+      "type": "object"
     },
     "Email": {
       "format": "email",
@@ -2797,6 +2826,42 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Plans showing the stretches of hedgerows to be removed",
+              "type": "string"
+            },
+            "value": {
+              "const": "hedgerowsInformation",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Evidence of the date of planting of the removed hedgerows",
+              "type": "string"
+            },
+            "value": {
+              "const": "hedgerowsInformation.plantingDate",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Heritage Statement",
               "type": "string"
             },
@@ -3216,6 +3281,24 @@
             },
             "value": {
               "const": "planningStatement",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Information the applicant considers relevant to the application",
+              "type": "string"
+            },
+            "value": {
+              "const": "relevantInformation",
               "type": "string"
             }
           },
@@ -3894,6 +3977,39 @@
       ],
       "description": "Types of planning documents and drawings"
     },
+    "FilesAsData": {
+      "$id": "#FilesAsData",
+      "additionalProperties": false,
+      "description": "File types that can optionally be provided by answering structured questions, rather than via document upload (see root `files` for uploads)",
+      "properties": {
+        "designAndAccessStatement": {
+          "$ref": "#/definitions/DesignAndAccessStatement"
+        },
+        "heritageStatement": {
+          "$ref": "#/definitions/HeritageStatement"
+        },
+        "locationPlan": {
+          "$ref": "#/definitions/GeoBoundary"
+        }
+      },
+      "type": "object"
+    },
+    "GeoBoundary": {
+      "additionalProperties": false,
+      "properties": {
+        "area": {
+          "$ref": "#/definitions/Area"
+        },
+        "site": {
+          "$ref": "#/definitions/GeoJSON"
+        }
+      },
+      "required": [
+        "site",
+        "area"
+      ],
+      "type": "object"
+    },
     "GeoJSON": {
       "anyOf": [
         {
@@ -3967,6 +4083,52 @@
       "required": [
         "geometries",
         "type"
+      ],
+      "type": "object"
+    },
+    "HeritageStatement": {
+      "additionalProperties": false,
+      "properties": {
+        "designated.WHS": {
+          "$ref": "#/definitions/HeritageStatementBase"
+        },
+        "designated.conservationArea": {
+          "$ref": "#/definitions/HeritageStatementBase"
+        },
+        "listed": {
+          "$ref": "#/definitions/HeritageStatementBase"
+        },
+        "monument": {
+          "$ref": "#/definitions/HeritageStatementBase"
+        }
+      },
+      "type": "object"
+    },
+    "HeritageStatementBase": {
+      "additionalProperties": false,
+      "properties": {
+        "designationDescription": {
+          "type": "string"
+        },
+        "improvements": {
+          "type": "string"
+        },
+        "managedImpact": {
+          "type": "string"
+        },
+        "projectDescpription": {
+          "type": "string"
+        },
+        "propertyDescription": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "designationDescription",
+        "propertyDescription",
+        "projectDescpription",
+        "managedImpact",
+        "improvements"
       ],
       "type": "object"
     },
@@ -4095,21 +4257,8 @@
           ]
         },
         "boundary": {
-          "additionalProperties": false,
-          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary",
-          "properties": {
-            "area": {
-              "$ref": "#/definitions/Area"
-            },
-            "site": {
-              "$ref": "#/definitions/GeoJSON"
-            }
-          },
-          "required": [
-            "site",
-            "area"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/GeoBoundary",
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
         },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
@@ -4345,21 +4494,8 @@
       "description": "Proposal details for project sites within the Greater London Authority (GLA) area",
       "properties": {
         "boundary": {
-          "additionalProperties": false,
-          "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary",
-          "properties": {
-            "area": {
-              "$ref": "#/definitions/Area"
-            },
-            "site": {
-              "$ref": "#/definitions/GeoJSON"
-            }
-          },
-          "required": [
-            "site",
-            "area"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/GeoBoundary",
+          "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary"
         },
         "charging": {
           "additionalProperties": false,
@@ -23549,21 +23685,8 @@
           ]
         },
         "boundary": {
-          "additionalProperties": false,
-          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary",
-          "properties": {
-            "area": {
-              "$ref": "#/definitions/Area"
-            },
-            "site": {
-              "$ref": "#/definitions/GeoJSON"
-            }
-          },
-          "required": [
-            "site",
-            "area"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/GeoBoundary",
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
         },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
@@ -23760,6 +23883,9 @@
         },
         "application": {
           "$ref": "#/definitions/Application"
+        },
+        "files": {
+          "$ref": "#/definitions/FilesAsData"
         },
         "property": {
           "$ref": "#/definitions/Property"

--- a/types/Schema.ts
+++ b/types/Schema.ts
@@ -4,6 +4,7 @@ import {PreAssessment} from './schema/PreAssessment';
 import {Responses} from './schema/Responses';
 import {Applicant} from './schema/data/Applicant';
 import {Application} from './schema/data/Application';
+import {FilesAsData} from './schema/data/Files';
 import {Property} from './schema/data/Property';
 import {Proposal} from './schema/data/Proposal';
 import {User} from './schema/data/User';
@@ -19,6 +20,7 @@ export interface Schema {
     applicant: Applicant;
     property: Property;
     proposal: Proposal;
+    files?: FilesAsData;
   };
   preAssessment?: PreAssessment;
   responses: Responses;

--- a/types/enums/ApplicationTypes.ts
+++ b/types/enums/ApplicationTypes.ts
@@ -3,8 +3,10 @@
  */
 export const ApplicationTypes = {
   advertConsent: 'Consent to display an advertisement',
-  'amendment.minorMaterial':'Consent to make small (minor material) changes to a project with planning permission',
-  'amendment.nonMaterial': 'Consent to make small (non-material) changes to a project with planning permission',
+  'amendment.minorMaterial':
+    'Consent to make small (minor material) changes to a project with planning permission',
+  'amendment.nonMaterial':
+    'Consent to make small (non-material) changes to a project with planning permission',
   hazardousSubstanceConsent:
     'Consent to move and dispose of hazardous substances',
   hedgerowRemovalNotice: 'Notice to remove a hedge',

--- a/types/enums/FileTypes.ts
+++ b/types/enums/FileTypes.ts
@@ -34,8 +34,10 @@ export const FileTypes = {
   'floorPlan.proposed': 'Floor plan - proposed',
   foulDrainageAssessment: 'Foul drainage assessment',
   geodiversityAssessment: 'Geodiversity assessment',
-  hedgerowsInformation: 'Plans showing the stretches of hedgerows to be removed',
-  'hedgerowsInformation.plantingDate': 'Evidence of the date of planting of the removed hedgerows',
+  hedgerowsInformation:
+    'Plans showing the stretches of hedgerows to be removed',
+  'hedgerowsInformation.plantingDate':
+    'Evidence of the date of planting of the removed hedgerows',
   heritageStatement: 'Heritage Statement',
   hydrologicalAssessment: 'Hydrological and hydrogeological assessment',
   hydrologyReport: 'Hydrology report',
@@ -62,7 +64,8 @@ export const FileTypes = {
   'photographs.existing': 'Photographs - existing',
   'photographs.proposed': 'Photographs - proposed',
   planningStatement: 'Planning statement',
-  relevantInformation: 'Information the applicant considers relevant to the application',
+  relevantInformation:
+    'Information the applicant considers relevant to the application',
   'roofPlan.existing': 'Roof plan - existing',
   'roofPlan.proposed': 'Roof plan - proposed',
   'sections.existing': 'Sections - existing',

--- a/types/schema/data/Files.ts
+++ b/types/schema/data/Files.ts
@@ -1,0 +1,33 @@
+import {GeoBoundary} from './shared';
+
+/**
+ * @id #FilesAsData
+ * @description File types that can optionally be provided by answering structured questions, rather than via document upload (see root `files` for uploads)
+ */
+export type FilesAsData = {
+  designAndAccessStatement?: DesignAndAccessStatement;
+  heritageStatement?: HeritageStatement;
+  locationPlan?: GeoBoundary;
+};
+
+export interface DesignAndAccessStatement {
+  propertyDescription: string;
+  projectDescription: string;
+  accessAndLayout: string;
+  landscapingChanges: string;
+}
+
+export type HeritageStatementBase = {
+  designationDescription: string;
+  propertyDescription: string;
+  projectDescpription: string;
+  managedImpact: string;
+  improvements: string;
+};
+
+export interface HeritageStatement {
+  'designated.conservationArea'?: HeritageStatementBase;
+  listed?: HeritageStatementBase;
+  monument?: HeritageStatementBase;
+  'designated.WHS'?: HeritageStatementBase;
+}

--- a/types/schema/data/Property.ts
+++ b/types/schema/data/Property.ts
@@ -1,8 +1,7 @@
-import {GeoJSON} from 'geojson';
 import {PlanningDesignations} from '../../enums/PlanningConstraints';
 import {PropertyTypes} from '../../enums/PropertyTypes';
-import {Area, URL} from '../../utils';
-import {Materials} from './shared';
+import {URL} from '../../utils';
+import {GeoBoundary, Materials} from './shared';
 
 /**
  * @id #Property
@@ -40,10 +39,7 @@ export interface UKProperty {
   /**
    * @description HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary
    */
-  boundary?: {
-    site: GeoJSON;
-    area: Area;
-  };
+  boundary?: GeoBoundary;
   /**
    * @description Planning constraints and policies that intersect with this site and may impact or restrict development
    */

--- a/types/schema/data/Proposal.ts
+++ b/types/schema/data/Proposal.ts
@@ -1,4 +1,3 @@
-import {GeoJSON} from 'geojson';
 import {
   OpenSpaceTypes,
   OpenSpaceDesignations,
@@ -6,7 +5,7 @@ import {
 } from '../../enums/Nature';
 import {ProjectTypes} from '../../enums/ProjectTypes';
 import {Area, Date} from '../../utils';
-import {Materials} from './shared';
+import {GeoBoundary, Materials} from './shared';
 
 /**
  * @id #Proposal
@@ -20,10 +19,7 @@ export interface BaseProposal {
   /**
    * @description Location plan boundary proposed by the user, commonly referred to as the red line boundary
    */
-  boundary?: {
-    site: GeoJSON;
-    area: Area;
-  };
+  boundary?: GeoBoundary;
   date?: ProposalDates;
   /**
    * @description Proposed materials, if applicable to projectType

--- a/types/schema/data/shared.ts
+++ b/types/schema/data/shared.ts
@@ -1,3 +1,6 @@
+import {GeoJSON} from 'geojson';
+import {Area} from '../../utils';
+
 export type Materials = {
   boundary?: string;
   door?: string;
@@ -7,4 +10,9 @@ export type Materials = {
   wall?: string;
   window?: string;
   other?: string;
+};
+
+export type GeoBoundary = {
+  site: GeoJSON;
+  area: Area;
 };


### PR DESCRIPTION
For certain supported file types, Planx is beginning to offer applicants an option to provide the necessary information by uploading a document _or_ by answering a set of structured questions equivalent to the contents of the traditional physical document.

Currently, if the user choses the question route, those answers are exclusively being passed along via the `responses` section of the schema. But we want to make them easier to parse for reporting, so this introduces a _new_ optional `data.files` key.

Based on these Planx services:
- https://editor.planx.uk/opensystemslab/design-and-access-statement-form,mQQItUM4m0
- https://editor.planx.uk/opensystemslab/heritage-statement-form,r5w5NAGZvv