### PR TITLE
chore: update `ApplicationTypes`

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -552,7 +552,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Consent to do works on affecting ordinary watercourses or land drainage",
+              "const": "Consent to do works affecting ordinary watercourses or land drainage",
               "type": "string"
             },
             "value": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -552,6 +552,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Consent to do works on affecting ordinary watercourses or land drainage",
+              "type": "string"
+            },
+            "value": {
+              "const": "landDrainageConsent",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Lawful Development Certificate",
               "type": "string"
             },
@@ -876,11 +894,65 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Prior Approval - Part 3 Class V",
+              "type": "string"
+            },
+            "value": {
+              "const": "pa.part3.classV",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Prior Approval - Put up a temporary structure",
               "type": "string"
             },
             "value": {
               "const": "pa.part4.classBB",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Prior Approval - Part 4 Class BC",
+              "type": "string"
+            },
+            "value": {
+              "const": "pa.part4.classBC",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Prior Approval - Part 4 Class CA",
+              "type": "string"
+            },
+            "value": {
+              "const": "pa.part4.classCA",
               "type": "string"
             }
           },
@@ -1074,11 +1146,83 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Prior Approval - Part 17 Class B",
+              "type": "string"
+            },
+            "value": {
+              "const": "pa.part17.classB",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Prior Approval - Part 17 Class C",
+              "type": "string"
+            },
+            "value": {
+              "const": "pa.part17.classC",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Prior Approval - Part 17 Class G",
+              "type": "string"
+            },
+            "value": {
+              "const": "pa.part17.classG",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Prior Approval - Specific Acts of Parliament or Local Orders",
               "type": "string"
             },
             "value": {
               "const": "pa.part18.classA",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Prior Approval - Part 19 Class TA",
+              "type": "string"
+            },
+            "value": {
+              "const": "pa.part19.classTA",
               "type": "string"
             }
           },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1830,6 +1830,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Rights of Way Order - Apply to move or close a path",
+              "type": "string"
+            },
+            "value": {
+              "const": "rightsOfWayOrder",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Works to trees",
               "type": "string"
             },

--- a/types/enums/ApplicationTypes.ts
+++ b/types/enums/ApplicationTypes.ts
@@ -13,7 +13,7 @@ export const ApplicationTypes = {
     'Consent to move and dispose of hazardous substances',
   hedgerowRemovalNotice: 'Notice to remove a hedge',
   landDrainageConsent:
-    'Consent to do works on affecting ordinary watercourses or land drainage',
+    'Consent to do works affecting ordinary watercourses or land drainage',
   ldc: 'Lawful Development Certificate',
   'ldc.proposed': 'Lawful Development Certificate - Proposed use',
   'ldc.existing': 'Lawful Development Certificate - Existing use',

--- a/types/enums/ApplicationTypes.ts
+++ b/types/enums/ApplicationTypes.ts
@@ -125,6 +125,7 @@ export const ApplicationTypes = {
     'Outline Planning Permission - Approval of reserved matters (major)',
   'pp.outline.major.someReserved':
     'Outline Planning Permission - Consent for the principle of a project specifying some details (major)',
+  rightsOfWayOrder: 'Rights of Way Order - Apply to move or close a path',
   wtt: 'Works to trees',
   'wtt.consent':
     'Works to trees - Consent to carry out works to a tree with a Tree Preservation Order',

--- a/types/enums/ApplicationTypes.ts
+++ b/types/enums/ApplicationTypes.ts
@@ -12,6 +12,8 @@ export const ApplicationTypes = {
   hazardousSubstanceConsent:
     'Consent to move and dispose of hazardous substances',
   hedgerowRemovalNotice: 'Notice to remove a hedge',
+  landDrainageConsent:
+    'Consent to do works on affecting ordinary watercourses or land drainage',
   ldc: 'Lawful Development Certificate',
   'ldc.proposed': 'Lawful Development Certificate - Proposed use',
   'ldc.existing': 'Lawful Development Certificate - Existing use',
@@ -41,7 +43,10 @@ export const ApplicationTypes = {
     'Prior Approval - Convert an agricultural building to a school',
   'pa.part3.classT':
     'Prior Approval - Convert a commercial building to a school',
+  'pa.part3.classV': 'Prior Approval - Part 3 Class V',
   'pa.part4.classBB': 'Prior Approval - Put up a temporary structure',
+  'pa.part4.classBC': 'Prior Approval - Part 4 Class BC',
+  'pa.part4.classCA': 'Prior Approval - Part 4 Class CA',
   'pa.part4.classE': 'Prior Approval - Use a building or land to shoot a film',
   'pa.part6':
     'Prior Approval - Alter or add new buildings to agricultural or forestry sites',
@@ -56,8 +61,12 @@ export const ApplicationTypes = {
   'pa.part11.classB': 'Prior Approval - Demolish a building',
   'pa.part14.classJ': 'Prior Approval - Install or change solar panels',
   'pa.part16.classA': 'Prior Approval - Install telecommunications equipment',
+  'pa.part17.classB': 'Prior Approval - Part 17 Class B',
+  'pa.part17.classC': 'Prior Approval - Part 17 Class C',
+  'pa.part17.classG': 'Prior Approval - Part 17 Class G',
   'pa.part18.classA':
     'Prior Approval - Specific Acts of Parliament or Local Orders',
+  'pa.part19.classTA': 'Prior Approval - Part 19 Class TA',
   'pa.part20.classA':
     'Prior Approval - Build homes on a detached blocks of flats',
   'pa.part20.classAA':


### PR DESCRIPTION
Based on service team notes/updates tracked here https://www.notion.so/opensystemslab/Payloads-Schema-Updates-8e632d514b004291a4b6d3f8eb08f6bb

We don't have nice "plain english" names for all the Prior Approvals yet, but seems best they get added to the list ASAP regardless for "completeness". 