### PR TITLE
fix: Update 'Build and move files' step to preserve new example folder structure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,12 @@ jobs:
           mv types/* "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }}/types"
 
           mkdir -p "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }}/examples"
-          cp -r examples/**/*.json "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }}/examples"
+          
+          # Copy JSON files, preserving directory structure
+          rsync -a --prune-empty-dirs --include '*/' --include '*.json' --exclude '*' examples/ "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }}/examples/"
+          
+          # Remove JSON files from source destination
+          find examples -type f -name "*.json" -delete
 
       - name: Checkout Dist Branch
         if: steps.version_check.outputs.changed == 'true'


### PR DESCRIPTION
## What does this PR do?
 - Fixes an issue identified on [most recent production deploy](https://github.com/theopensystemslab/digital-planning-data-schemas/actions/runs/9904681601/job/27362608050)
 - Copies JSON examples recursively, preserving folder structure
 - Removed source JSON files, generated by `pnpm build`

Tested locally, see results in `/daf` folder below - 
<img width="386" alt="image" src="https://github.com/user-attachments/assets/72af5a70-f176-46fb-852d-8b3f9576d0bd">
