### PR TITLE
feat: Add `/latest` directory containing most recently published version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/gts/",
   "rules": {
-    "node/no-unpublished-import": ["error", {
+    "n/no-unpublished-import": ["error", {
         "allowModules": ["vitest", "jsonschema"]
     }]
   }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,10 @@ jobs:
           # Remove JSON files from source destination
           find examples -type f -name "*.json" -delete
 
+          # Copy across new version to maintain a stable reference URL at /latest
+          rm -rf latest/*
+          cp -r "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }} "$GITHUB_WORKSPACE/latest"
+
       - name: Checkout Dist Branch
         if: steps.version_check.outputs.changed == 'true'
         run: |


### PR DESCRIPTION
## What does this PR do?
 - On publish of a new version, also copy the schemas, examples, and types to `/latest`
 - This means we get a stable URL always pointing to the latest published version at `https://theopensystemslab.github.io/digital-planning-data-schemas/lastest/schema/${schema}.json`
 - Relies on https://github.com/theopensystemslab/digital-planning-data-schemas/pull/206