### PR TITLE
fix: Correctly setup `/latest` and `/next` folders

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           find examples -type f -name "*.json" -delete
 
           # Copy across new version to maintain a stable reference URL at /latest
-          rm -rf latest/*
+          mkdir -p "$GITHUB_WORKSPACE/latest"
           cp -r "$GITHUB_WORKSPACE/v${{ steps.version_check.outputs.version }} "$GITHUB_WORKSPACE/latest"
 
       - name: Checkout Dist Branch
@@ -60,6 +60,10 @@ jobs:
         run: |
           git fetch origin dist
           git checkout -b dist origin/dist
+
+      - name: Cleanup old /latest folder
+        if: steps.version_check.outputs.changed == 'true'
+        run: rm -rf latest/*
 
       - name: Commit and Push Changes
         if: steps.version_check.outputs.changed == 'true'

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Move JSON schema files to /@next folder
         run: |
+          mkdir -p "$GITHUB_WORKSPACE/${{ env.VERSION }}"
           mv schemas/* "$GITHUB_WORKSPACE/${{ env.VERSION }}"
           mv types/* "$GITHUB_WORKSPACE/${{ env.VERSION }}/types"
 


### PR DESCRIPTION
## What does this PR do?
- Fixes failures in CI after merging #205 and #207
- Creates the required folders (on the current branch - it already exists only on the `dist` branch)