### PR TITLE
chore: Add `--frozen-lockfile` flag to CI process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.version_check.outputs.changed == 'true'  
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build and Move Files
         if: steps.version_check.outputs.changed == 'true'

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm install -g pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build JSON schema files
         run: pnpm build


### PR DESCRIPTION
## What's the problem?
 - Lockfile changes are currently introduced when running `pnpm i`, which then causes the `git fetch` command to fail
 
 ## What's the solution?
 - Add the `--frozen-lockfile` flag ([docs](https://pnpm.io/cli/install#--frozen-lockfile))

Note: This flag should be set to true by default in CI environments, but it certainly looks like this isn't quite working as expected in GitHub actions.

![image](https://github.com/user-attachments/assets/d4774001-9b78-4291-9753-63815ee0c5e9)
