### PR TITLE
chore: sync `ApplicationTypes` to Planx services spreadsheet

### DIFF
--- a/schemas/digitalPlanningApplication.json
+++ b/schemas/digitalPlanningApplication.json
@@ -537,6 +537,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Approval of details reserved by condition",
+              "type": "string"
+            },
+            "value": {
+              "const": "approval.conditions",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Approval of reserved matters",
               "type": "string"
             },
@@ -577,7 +595,7 @@
               "type": "string"
             },
             "value": {
-              "const": "environmnentalImpact",
+              "const": "environmentalImpact",
               "type": "string"
             }
           },
@@ -699,11 +717,11 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Lawful Development Certificate - Proposed use",
+              "const": "Lawful Development Certificate - Existing use lawful not to comply with a condition (S191C)",
               "type": "string"
             },
             "value": {
-              "const": "ldc.proposed",
+              "const": "ldc.breachOfCondition",
               "type": "string"
             }
           },
@@ -735,11 +753,11 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Lawful Development Certificate - Continue an existing use",
+              "const": "Lawful Development Certificate - Works to a Listed Building (S26H)",
               "type": "string"
             },
             "value": {
-              "const": "ldc.existing.regularise",
+              "const": "ldc.listedBuildingWorks",
               "type": "string"
             }
           },
@@ -753,11 +771,11 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Lawful Development Certificate - Lawful not to comply with a condition or limitation",
+              "const": "Lawful Development Certificate - Proposed use",
               "type": "string"
             },
             "value": {
-              "const": "ldc.condition",
+              "const": "ldc.proposed",
               "type": "string"
             }
           },
@@ -848,6 +866,132 @@
             },
             "value": {
               "const": "obligation.modify",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Onshore extraction of oil and gas",
+              "type": "string"
+            },
+            "value": {
+              "const": "onshoreExtractionOilAndGas",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Onshore extraction of oil and gas - Other",
+              "type": "string"
+            },
+            "value": {
+              "const": "onshoreExtractionOilAndGas.other",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Onshore extraction of oil and gas - Full planning permission for an extension to an existing site including associated development",
+              "type": "string"
+            },
+            "value": {
+              "const": "onshoreExtractionOilAndGas.pp.extension",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Onshore extraction of oil and gas - Full planning permission for waste development",
+              "type": "string"
+            },
+            "value": {
+              "const": "onshoreExtractionOilAndGas.pp.waste",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Onshore extraction of oil and gas - Full planning permission for oil and gas working including exploratory, appraisal and production phases",
+              "type": "string"
+            },
+            "value": {
+              "const": "onshoreExtractionOilAndGas.pp.working",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Onshore extraction of oil and gas - Review of conditions applying to Mineral Permissions (ROMPs)",
+              "type": "string"
+            },
+            "value": {
+              "const": "onshoreExtractionOilAndGas.review",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Onshore extraction of oil and gas - Variation of conditions",
+              "type": "string"
+            },
+            "value": {
+              "const": "onshoreExtractionOilAndGas.variation",
               "type": "string"
             }
           },
@@ -1455,7 +1599,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Prior Approval - Coal mining development by the Coal Authority for maintence or safety",
+              "const": "Prior Approval - Coal mining development by the Coal Authority for maintenance or safety",
               "type": "string"
             },
             "value": {
@@ -1892,24 +2036,6 @@
             },
             "value": {
               "const": "pp.mineralExtraction",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Planning Permission - Consent to extract oil and gas",
-              "type": "string"
-            },
-            "value": {
-              "const": "pp.onshoreExtractionOilAndGas",
               "type": "string"
             }
           },

--- a/types/schemas/digitalPlanningApplication/enums/ApplicationTypes.ts
+++ b/types/schemas/digitalPlanningApplication/enums/ApplicationTypes.ts
@@ -10,10 +10,11 @@ export const ApplicationTypes = {
   'amendment.nonMaterial':
     'Consent to make small (non-material) changes to a project with Planning Permission',
   approval: 'Planning approval',
+  'approval.conditions': 'Approval of details reserved by condition',
   'approval.reservedMatters': 'Approval of reserved matters',
   complianceConfirmation:
     'Written confirmation of compliance with a planning condition',
-  environmnentalImpact: 'Environmental Impact Decision',
+  environmentalImpact: 'Environmental Impact Decision',
   'environmentalImpact.scoping': 'Environmental Impact Decision - Scoping',
   'environmentalImpact.screening': 'Environmental Impact Decision - Screening',
   hazardousSubstanceConsent:
@@ -22,17 +23,30 @@ export const ApplicationTypes = {
   landDrainageConsent:
     'Consent to do works affecting ordinary watercourses or land drainage',
   ldc: 'Lawful Development Certificate',
-  'ldc.proposed': 'Lawful Development Certificate - Proposed use',
+  'ldc.breachOfCondition':
+    'Lawful Development Certificate - Existing use lawful not to comply with a condition (S191C)',
   'ldc.existing': 'Lawful Development Certificate - Existing use',
-  'ldc.existing.regularise':
-    'Lawful Development Certificate - Continue an existing use',
-  'ldc.condition':
-    'Lawful Development Certificate - Lawful not to comply with a condition or limitation',
+  'ldc.listedBuildingWorks':
+    'Lawful Development Certificate - Works to a Listed Building (S26H)',
+  'ldc.proposed': 'Lawful Development Certificate - Proposed use',
   listed: 'Consent to do works to a Listed Building',
   notifyCompletion: 'Notification of completion',
   obligation: 'Planning obligation',
   'obligation.discharge': 'Discharge a planning obligation',
   'obligation.modify': 'Modify a planning obligation',
+  onshoreExtractionOilAndGas: 'Onshore extraction of oil and gas',
+  'onshoreExtractionOilAndGas.other':
+    'Onshore extraction of oil and gas - Other',
+  'onshoreExtractionOilAndGas.pp.extension':
+    'Onshore extraction of oil and gas - Full planning permission for an extension to an existing site including associated development',
+  'onshoreExtractionOilAndGas.pp.waste':
+    'Onshore extraction of oil and gas - Full planning permission for waste development',
+  'onshoreExtractionOilAndGas.pp.working':
+    'Onshore extraction of oil and gas - Full planning permission for oil and gas working including exploratory, appraisal and production phases',
+  'onshoreExtractionOilAndGas.review':
+    'Onshore extraction of oil and gas - Review of conditions applying to Mineral Permissions (ROMPs)',
+  'onshoreExtractionOilAndGas.variation':
+    'Onshore extraction of oil and gas - Variation of conditions',
   pa: 'Prior Approval',
   'pa.part1.classA': 'Prior Approval - Larger extension to a house',
   'pa.part1.classAA': 'Prior Approval - Adding storeys to a house',
@@ -86,7 +100,7 @@ export const ApplicationTypes = {
     'Prior Approval - Other developments ancillary to mining operations',
   'pa.part17.classC': 'Prior Approval - Developments for maintenance or safety',
   'pa.part17.classG':
-    'Prior Approval - Coal mining development by the Coal Authority for maintence or safety',
+    'Prior Approval - Coal mining development by the Coal Authority for maintenance or safety',
   'pa.part18.classA':
     'Prior Approval - Development under private acts or orders',
   'pa.part19.classTA': 'Prior Approval - Development on a closed defence site',
@@ -128,8 +142,6 @@ export const ApplicationTypes = {
     'Planning Permission - Technical details consent for minor development',
   'pp.mineralExtraction':
     'Planning Permission - Consent to extract minerals and related development, such as temporary buildings and roads',
-  'pp.onshoreExtractionOilAndGas':
-    'Planning Permission - Consent to extract oil and gas',
   'pp.outline': 'Planning permission - Outline for proposed development',
   'pp.outline.all':
     'Outline Planning Permission - Consent for the principle of a project witholding all details',


### PR DESCRIPTION
We had a few lingering out of sync variables - now synced to [this tab](https://docs.google.com/spreadsheets/d/1ePihRD37-2071Wq6t2Y7QtBt7juySWuVP6SAF6T-0vo/edit?gid=814404181#gid=814404181) for consistent external communication

Also pulled in the typos specific to application types from #213 