### PR TITLE
fix: Update `@next` GitHub action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,10 +61,6 @@ jobs:
           git fetch origin dist
           git checkout -b dist origin/dist
 
-      - name: Cleanup old /latest folder
-        if: steps.version_check.outputs.changed == 'true'
-        run: rm -rf latest/*
-
       - name: Commit and Push Changes
         if: steps.version_check.outputs.changed == 'true'
         run: |

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout Dist Branch
         run: |
           git fetch origin dist
-          git checkout -b dist origin/dist
+          git checkout -f dist
 
       - name: Commit and Push Changes
         run: |

--- a/examples/application/data/planningPermission/fullHouseholderInConservationArea.ts
+++ b/examples/application/data/planningPermission/fullHouseholderInConservationArea.ts
@@ -1,4 +1,4 @@
-import { Application } from "../../../../types/schemas/application";
+import {Application} from '../../../../types/schemas/application';
 
 const version = process.env['VERSION'] || '@next';
 


### PR DESCRIPTION
This action is currently failing due to the way generating new files and checking out dist is working. Adding the -f (force) flag resolves this.