### PR TITLE
chore: `DevelopmentType` enum

### DIFF
--- a/types/schemas/prototypeApplication/enums/DevelopmentType.ts
+++ b/types/schemas/prototypeApplication/enums/DevelopmentType.ts
@@ -1,0 +1,47 @@
+/**
+ * @description Change of use
+ */
+type ChangeOfUse = 'changeOfUse';
+
+/**
+ * @description Change of use of an existing single home
+ */
+type ChangeOfUseFrom = 'changeOfUseFrom';
+
+/**
+ * @description Change of use to a home
+ */
+type ChangeOfUseTo = 'changeOfUseTo';
+
+/**
+ * @description Conversion
+ */
+type Conversion = 'conversion';
+
+/**
+ * @description Extension
+ */
+type Extension = 'extension';
+
+/**
+ * @description New build
+ */
+type NewBuild = 'newBuild';
+
+/**
+ * @description Not known
+ */
+type NotKnown = 'notKnown';
+
+/**
+ * @id #DevelopmentType
+ * @description Development types
+ */
+export type DevelopmentType =
+  | ChangeOfUse
+  | ChangeOfUseFrom
+  | ChangeOfUseTo
+  | Conversion
+  | Extension
+  | NewBuild
+  | NotKnown;


### PR DESCRIPTION
Converts `DevelopmentType` from the old enum format to the new format, please see https://github.com/theopensystemslab/digital-planning-data-schemas/pull/218 for context.