### PR TITLE
feat: define optional `overrides` on PlanX metadata

### DIFF
--- a/schemas/application.json
+++ b/schemas/application.json
@@ -8577,6 +8577,9 @@
             "flowId": {
               "$ref": "#/definitions/UUID"
             },
+            "overrides": {
+              "$ref": "#/definitions/UserOverrides"
+            },
             "url": {
               "$ref": "#/definitions/URL"
             }
@@ -25438,6 +25441,78 @@
         "sameAsSiteAddress",
         "town"
       ],
+      "type": "object"
+    },
+    "UserOverrides": {
+      "$id": "#UserOverrides",
+      "additionalProperties": false,
+      "description": "PlanX fetches and suggests administrative data to users throughout a service; if a user contests or changes this data, those details will come through here",
+      "properties": {
+        "property": {
+          "additionalProperties": false,
+          "properties": {
+            "planning": {
+              "additionalProperties": false,
+              "properties": {
+                "designations": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "entityId": {
+                        "type": "string"
+                      },
+                      "sourceIntersects": {
+                        "const": true,
+                        "type": "boolean"
+                      },
+                      "userIntersects": {
+                        "const": false,
+                        "type": "boolean"
+                      },
+                      "userReason": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "entityId",
+                      "sourceIntersects",
+                      "userIntersects",
+                      "userReason"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "designations"
+              ],
+              "type": "object"
+            },
+            "type": {
+              "additionalProperties": false,
+              "properties": {
+                "sourceClassification": {
+                  "type": "string"
+                },
+                "userClassification": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "sourceClassification",
+                "userClassification"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
       "type": "object"
     }
   },

--- a/types/schemas/application/Metadata.ts
+++ b/types/schemas/application/Metadata.ts
@@ -94,6 +94,28 @@ export interface FeeExplanation {
 }
 
 /**
+ * @id #UserOverrides
+ * @description PlanX fetches and suggests administrative data to users throughout a service; if a user contests or changes this data, those details will come through here
+ */
+export interface UserOverrides {
+  property?: {
+    type?: {
+      sourceClassification: string;
+      userClassification: string;
+    };
+    planning?: {
+      designations: {
+        value: string; // @TODO enum
+        entityId: string;
+        sourceIntersects: true;
+        userIntersects: false;
+        userReason: string;
+      }[];
+    };
+  };
+}
+
+/**
  * @id #PlanXMetadata
  * @description Additional metadata associated with applications submitted via PlanX
  */
@@ -104,5 +126,6 @@ export interface PlanXMetadata extends BaseMetadata {
     url: URL;
     files: RequestedFiles;
     fee: FeeExplanation | FeeExplanationNotApplicable;
+    overrides?: UserOverrides;
   };
 }


### PR DESCRIPTION
PlanX fetches & suggestions administrative data to users throughout a service (eg planning constraints), and we always present users with an option to contest or change this data if it is outdated or not applicable. 

If the user has chosen to override the suggested data, we want to ensure we still send planning officers both the original "source" data and the "user" override information for assessment and feedback.

This mocks up a proposed structure for sharing this !

Will wait for #236 to merge first, then rebase here.