### PR TITLE
chore: support site address ranges

### DIFF
--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -4195,9 +4195,26 @@
           "type": "string"
         },
         "pao": {
+          "description": "Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties",
+          "title": "Primary Addressable Object start range and/or building description",
+          "type": "string"
+        },
+        "paoEnd": {
+          "description": "Combined `PAO_END_NUMBER`, `PAO_END_SUFFIX` OS LPI properties",
+          "title": "Primary Addressable Object (PAO) end range",
           "type": "string"
         },
         "postcode": {
+          "type": "string"
+        },
+        "sao": {
+          "description": "Combined `SAO_START_NUMBER`, `SAO_START_SUFFIX`, `SAO_TEXT` OS LPI properties",
+          "title": "Secondary Addressable Object (SAO) start range and/or building description",
+          "type": "string"
+        },
+        "saoEnd": {
+          "description": "Combined `SAO_END_NUMBER`, `SAO_END_SUFFIX` OS LPI properties",
+          "title": "Secondary Addressable Object (SAO) end range",
           "type": "string"
         },
         "singleLine": {

--- a/types/schemas/prototypeApplication/data/Property.ts
+++ b/types/schemas/prototypeApplication/data/Property.ts
@@ -134,7 +134,26 @@ export interface OSAddress extends SiteAddress {
    * @maxLength 8
    */
   usrn: string;
+  /**
+   * @title Primary Addressable Object start range and/or building description
+   * @description Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties
+   */
   pao: string;
+  /**
+   * @title Primary Addressable Object (PAO) end range
+   * @description Combined `PAO_END_NUMBER`, `PAO_END_SUFFIX` OS LPI properties
+   */
+  paoEnd?: string;
+  /**
+   * @title Secondary Addressable Object (SAO) start range and/or building description
+   * @description Combined `SAO_START_NUMBER`, `SAO_START_SUFFIX`, `SAO_TEXT` OS LPI properties
+   */
+  sao?: string;
+  /**
+   * @title Secondary Addressable Object (SAO) end range
+   * @description Combined `SAO_END_NUMBER`, `SAO_END_SUFFIX` OS LPI properties
+   */
+  saoEnd?: string;
   street: string;
   town: string;
   postcode: string;


### PR DESCRIPTION
Follows on from this PlanX change: https://github.com/theopensystemslab/planx-new/pull/3670

Also addresses Idox feedback that they expected to see support for address ranges more aligned with original OS source - so annotations hopefully help clarify how we map these ! 

`pao` remains the only required field, `paoEnd`, `sao`, and `saoEnd` are optional.