### PR TITLE
fix: change applicant ownership tenant to lessee

### DIFF
--- a/schemas/application.json
+++ b/schemas/application.json
@@ -8359,7 +8359,7 @@
         "interest": {
           "enum": [
             "owner",
-            "tenant",
+            "lessee",
             "occupier",
             "other"
           ],
@@ -8400,7 +8400,7 @@
         "interest": {
           "enum": [
             "owner",
-            "tenant",
+            "lessee",
             "occupier",
             "other"
           ],
@@ -8436,7 +8436,7 @@
         "interest": {
           "enum": [
             "owner",
-            "tenant",
+            "lessee",
             "occupier",
             "other"
           ],
@@ -8494,7 +8494,7 @@
             "owner",
             "owner.sole",
             "owner.co",
-            "tenant",
+            "lessee",
             "occupier",
             "other"
           ],

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -4753,7 +4753,7 @@
     "OwnershipInterest": {
       "enum": [
         "owner",
-        "tenant",
+        "lessee",
         "occupier",
         "other"
       ],

--- a/types/schemas/application/data/Applicant.ts
+++ b/types/schemas/application/data/Applicant.ts
@@ -40,7 +40,7 @@ export interface Ownership {
     | 'owner'
     | 'owner.sole'
     | 'owner.co'
-    | 'tenant'
+    | 'lessee'
     | 'occupier'
     | 'other';
   certificate?: 'a' | 'b' | 'c' | 'd';
@@ -82,7 +82,7 @@ export type Owners = OwnersNoticeGiven | OwnersNoNoticeGiven | OwnersNoticeDate;
 export interface BaseOwners {
   name: string;
   address: Address | string;
-  interest?: 'owner' | 'tenant' | 'occupier' | 'other';
+  interest?: 'owner' | 'lessee' | 'occupier' | 'other';
 }
 
 // LDC requires `noticeGiven`, and `noNoticeReason` if false

--- a/types/schemas/prototypeApplication/data/Applicant.ts
+++ b/types/schemas/prototypeApplication/data/Applicant.ts
@@ -67,7 +67,7 @@ export interface ApplicantAddressNotSameSite extends UserAddress {
   sameAsSiteAddress: false;
 }
 
-export type OwnershipInterest = 'owner' | 'tenant' | 'occupier' | 'other';
+export type OwnershipInterest = 'owner' | 'lessee' | 'occupier' | 'other';
 
 export interface BaseOwners {
   name: string;


### PR DESCRIPTION
Schema change to align with content. The correct term for a leaseholder with interest in land is lessee, not tenant. Agricultural tenants are a wholly separate issue and not affected by this fix.