### PR TITLE
chore: refactor more `/shared` types

### DIFF
--- a/examples/application/data/landDrainageConsent.ts
+++ b/examples/application/data/landDrainageConsent.ts
@@ -46,7 +46,7 @@ export const landDrainageConsent: Application = {
               last: 'of Mortain',
             },
             email: 'countbobby@email.org',
-            phone: '012345678901',
+            phone: {primary: '012345678901'},
           },
         },
         {
@@ -63,7 +63,7 @@ export const landDrainageConsent: Application = {
               last: 'De Leybourne',
             },
             email: 'baronsarerevolting@email.org',
-            phone: '098765432109',
+            phone: {primary: '098765432109'},
             company: {
               name: "The Barons' Revolt",
             },

--- a/examples/application/landDrainageConsent.json
+++ b/examples/application/landDrainageConsent.json
@@ -41,7 +41,9 @@
               "last": "of Mortain"
             },
             "email": "countbobby@email.org",
-            "phone": "012345678901"
+            "phone": {
+              "primary": "012345678901"
+            }
           }
         },
         {
@@ -58,7 +60,9 @@
               "last": "De Leybourne"
             },
             "email": "baronsarerevolting@email.org",
-            "phone": "098765432109",
+            "phone": {
+              "primary": "098765432109"
+            },
             "company": {
               "name": "The Barons' Revolt"
             }

--- a/schemas/application.json
+++ b/schemas/application.json
@@ -7919,9 +7919,8 @@
       "type": "object"
     },
     "OSAddress": {
-      "$id": "#OSAddress",
       "additionalProperties": false,
-      "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium",
+      "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium LPI source",
       "properties": {
         "latitude": {
           "description": "Latitude coordinate in EPSG:4326 (WGS84)",
@@ -7968,6 +7967,7 @@
           "type": "string"
         },
         "title": {
+          "description": "Single line address description",
           "type": "string"
         },
         "town": {
@@ -8007,6 +8007,7 @@
         "x",
         "y"
       ],
+      "title": "#OSAddress",
       "type": "object"
     },
     "OpenSpaceDesignation": {
@@ -24017,7 +24018,6 @@
       "type": "object"
     },
     "ProposedAddress": {
-      "$id": "#ProposedAddress",
       "additionalProperties": false,
       "description": "Address information for sites without a known Unique Property Reference Number (UPRN)",
       "properties": {
@@ -24034,6 +24034,7 @@
           "type": "string"
         },
         "title": {
+          "description": "Single line address description",
           "type": "string"
         },
         "x": {
@@ -24053,6 +24054,7 @@
         "x",
         "y"
       ],
+      "title": "#ProposedAddress",
       "type": "object"
     },
     "ProtectedSpaceDesignation": {
@@ -24245,6 +24247,22 @@
         }
       },
       "type": "object"
+    },
+    "Region": {
+      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
+      "enum": [
+        "North East",
+        "North West",
+        "Yorkshire and The Humber",
+        "East Midlands",
+        "West Midlands",
+        "East of England",
+        "London",
+        "South East",
+        "South West"
+      ],
+      "title": "#Region",
+      "type": "string"
     },
     "RequestedFiles": {
       "$id": "#RequestedFiles",
@@ -25068,7 +25086,7 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/UKRegion"
+          "$ref": "#/definitions/Region"
         },
         "trees": {
           "additionalProperties": false,
@@ -25126,22 +25144,6 @@
         "type"
       ],
       "type": "object"
-    },
-    "UKRegion": {
-      "$id": "#UKRegion",
-      "description": "The UK region that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
-      "enum": [
-        "North East",
-        "North West",
-        "Yorkshire and The Humber",
-        "East Midlands",
-        "West Midlands",
-        "East of England",
-        "London",
-        "South East",
-        "South West"
-      ],
-      "type": "string"
     },
     "UKResidentialUnitType": {
       "$id": "#UKResidentialUnitType",

--- a/schemas/application.json
+++ b/schemas/application.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "definitions": {
     "Address": {
-      "$id": "#Address",
       "additionalProperties": false,
       "description": "Address information for a person associated with this application not at the property address",
       "properties": {
@@ -96,10 +95,10 @@
             }
           },
           "required": [
-            "name",
+            "address",
             "email",
-            "phone",
-            "address"
+            "name",
+            "phone"
           ],
           "type": "object"
         },
@@ -237,208 +236,6 @@
         }
       ],
       "description": "Information about this planning application"
-    },
-    "ApplicationDeclaration": {
-      "$id": "#ApplicationDeclaration",
-      "additionalProperties": false,
-      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
-      "properties": {
-        "accurate": {
-          "type": "boolean"
-        },
-        "connection": {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "type": "string"
-            },
-            "value": {
-              "enum": [
-                "employee",
-                "relation.employee",
-                "electedMember",
-                "relation.electedMember",
-                "none"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "value"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "accurate",
-        "connection"
-      ],
-      "type": "object"
-    },
-    "ApplicationFee": {
-      "$id": "#ApplicationFee",
-      "additionalProperties": false,
-      "description": "The costs associated with this application",
-      "properties": {
-        "calculated": {
-          "description": "Total calculated fee in GBP",
-          "type": "number"
-        },
-        "category": {
-          "additionalProperties": false,
-          "description": "Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2",
-          "properties": {
-            "eight": {
-              "description": "Category 8 - Car parks or access roads",
-              "type": "number"
-            },
-            "eleven": {
-              "additionalProperties": false,
-              "properties": {
-                "one": {
-                  "description": "Category 11(1) - Mining operations",
-                  "type": "number"
-                },
-                "two": {
-                  "description": "Category 11(2) - Other operations",
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "five": {
-              "description": "Category 5 - Plant equipment or machinery",
-              "type": "number"
-            },
-            "four": {
-              "description": "Category 4 - Glasshouses on agricultural land",
-              "type": "number"
-            },
-            "fourteen": {
-              "description": "Category 14 - Other change of use",
-              "type": "number"
-            },
-            "nine": {
-              "description": "Category 9 - Exploratory drilling",
-              "type": "number"
-            },
-            "one": {
-              "description": "Category 1 - New homes",
-              "type": "number"
-            },
-            "sixAndSeven": {
-              "description": "Category 6 and 7 - Home or curtilage of home",
-              "type": "number"
-            },
-            "ten": {
-              "description": "Category 10 - Winning and working of oil or natural gas",
-              "type": "number"
-            },
-            "thirteen": {
-              "description": "Category 13 - Waste disposal",
-              "type": "number"
-            },
-            "three": {
-              "description": "Category 3 - Agricultural buildings",
-              "type": "number"
-            },
-            "twelve": {
-              "additionalProperties": false,
-              "properties": {
-                "one": {
-                  "description": "Category 12(1) - Change of use from single home to homes",
-                  "type": "number"
-                },
-                "two": {
-                  "description": "Category 12(2) - Change of use to home",
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "two": {
-              "description": "Category 2 - Other new buildings",
-              "type": "number"
-            }
-          },
-          "type": "object"
-        },
-        "exemption": {
-          "additionalProperties": false,
-          "properties": {
-            "disability": {
-              "type": "boolean"
-            },
-            "resubmission": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "disability",
-            "resubmission"
-          ],
-          "type": "object"
-        },
-        "payable": {
-          "description": "Total payable fee after any exemptions or reductions in GBP",
-          "type": "number"
-        },
-        "reduction": {
-          "additionalProperties": false,
-          "properties": {
-            "alternative": {
-              "type": "boolean"
-            },
-            "parishCouncil": {
-              "type": "boolean"
-            },
-            "sports": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "alternative",
-            "parishCouncil",
-            "sports"
-          ],
-          "type": "object"
-        },
-        "reference": {
-          "additionalProperties": false,
-          "properties": {
-            "govPay": {
-              "description": "GOV.UK Pay payment reference number",
-              "type": "string"
-            }
-          },
-          "required": [
-            "govPay"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "calculated",
-        "payable",
-        "exemption",
-        "reduction"
-      ],
-      "type": "object"
-    },
-    "ApplicationFeeNotApplicable": {
-      "$id": "#ApplicationFeeNotApplicable",
-      "additionalProperties": false,
-      "description": "An indicator that an application fee does not apply to this application type or journey",
-      "properties": {
-        "notApplicable": {
-          "const": true,
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "notApplicable"
-      ],
-      "type": "object"
     },
     "ApplicationType": {
       "$id": "#ApplicationType",
@@ -2448,12 +2245,12 @@
         }
       },
       "required": [
-        "type",
-        "name",
-        "email",
-        "phone",
         "address",
-        "siteContact"
+        "email",
+        "name",
+        "phone",
+        "siteContact",
+        "type"
       ],
       "type": "object"
     },
@@ -2464,15 +2261,15 @@
           "$ref": "#/definitions/CommunityInfrastructureLevy"
         },
         "declaration": {
-          "$ref": "#/definitions/ApplicationDeclaration"
+          "$ref": "#/definitions/Declaration"
         },
         "fee": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ApplicationFee"
+              "$ref": "#/definitions/Fee"
             },
             {
-              "$ref": "#/definitions/ApplicationFeeNotApplicable"
+              "$ref": "#/definitions/FeeNotApplicable"
             }
           ]
         },
@@ -2989,6 +2786,65 @@
       ],
       "type": "object"
     },
+    "ContactDetails": {
+      "additionalProperties": false,
+      "description": "Contact details for a person associated with this application",
+      "properties": {
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "email",
+        "phone"
+      ],
+      "title": "#ContactDetails",
+      "type": "object"
+    },
     "Date": {
       "format": "date",
       "type": "string"
@@ -2998,6 +2854,43 @@
       "format": "date-time",
       "pattern": "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$",
       "type": "string"
+    },
+    "Declaration": {
+      "additionalProperties": false,
+      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
+      "properties": {
+        "accurate": {
+          "type": "boolean"
+        },
+        "connection": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "value": {
+              "enum": [
+                "employee",
+                "relation.employee",
+                "electedMember",
+                "relation.electedMember",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "accurate",
+        "connection"
+      ],
+      "title": "#Declaration",
+      "type": "object"
     },
     "DesignAndAccessStatement": {
       "additionalProperties": false,
@@ -3307,6 +3200,156 @@
       ],
       "type": "object"
     },
+    "Fee": {
+      "additionalProperties": false,
+      "description": "The costs associated with this application",
+      "properties": {
+        "calculated": {
+          "description": "Total calculated fee in GBP",
+          "type": "number"
+        },
+        "category": {
+          "additionalProperties": false,
+          "description": "Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2",
+          "properties": {
+            "eight": {
+              "description": "Category 8 - Car parks or access roads",
+              "type": "number"
+            },
+            "eleven": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "description": "Category 11(1) - Mining operations",
+                  "type": "number"
+                },
+                "two": {
+                  "description": "Category 11(2) - Other operations",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "five": {
+              "description": "Category 5 - Plant equipment or machinery",
+              "type": "number"
+            },
+            "four": {
+              "description": "Category 4 - Glasshouses on agricultural land",
+              "type": "number"
+            },
+            "fourteen": {
+              "description": "Category 14 - Other change of use",
+              "type": "number"
+            },
+            "nine": {
+              "description": "Category 9 - Exploratory drilling",
+              "type": "number"
+            },
+            "one": {
+              "description": "Category 1 - New homes",
+              "type": "number"
+            },
+            "sixAndSeven": {
+              "description": "Category 6 and 7 - Home or curtilage of home",
+              "type": "number"
+            },
+            "ten": {
+              "description": "Category 10 - Winning and working of oil or natural gas",
+              "type": "number"
+            },
+            "thirteen": {
+              "description": "Category 13 - Waste disposal",
+              "type": "number"
+            },
+            "three": {
+              "description": "Category 3 - Agricultural buildings",
+              "type": "number"
+            },
+            "twelve": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "description": "Category 12(1) - Change of use from single home to homes",
+                  "type": "number"
+                },
+                "two": {
+                  "description": "Category 12(2) - Change of use to home",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "two": {
+              "description": "Category 2 - Other new buildings",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "exemption": {
+          "additionalProperties": false,
+          "properties": {
+            "disability": {
+              "type": "boolean"
+            },
+            "resubmission": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "disability",
+            "resubmission"
+          ],
+          "type": "object"
+        },
+        "payable": {
+          "description": "Total payable fee after any exemptions or reductions in GBP",
+          "type": "number"
+        },
+        "reduction": {
+          "additionalProperties": false,
+          "properties": {
+            "alternative": {
+              "type": "boolean"
+            },
+            "parishCouncil": {
+              "type": "boolean"
+            },
+            "sports": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "alternative",
+            "parishCouncil",
+            "sports"
+          ],
+          "type": "object"
+        },
+        "reference": {
+          "additionalProperties": false,
+          "properties": {
+            "govPay": {
+              "description": "GOV.UK Pay payment reference number",
+              "type": "string"
+            }
+          },
+          "required": [
+            "govPay"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "calculated",
+        "payable",
+        "exemption",
+        "reduction"
+      ],
+      "title": "#Fee",
+      "type": "object"
+    },
     "FeeExplanation": {
       "$id": "#FeeExplanation",
       "additionalProperties": false,
@@ -3450,6 +3493,21 @@
       "required": [
         "notApplicable"
       ],
+      "type": "object"
+    },
+    "FeeNotApplicable": {
+      "additionalProperties": false,
+      "description": "An indicator that an application fee does not apply to this application type or journey",
+      "properties": {
+        "notApplicable": {
+          "const": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "notApplicable"
+      ],
+      "title": "#FeeNotApplicable",
       "type": "object"
     },
     "File": {
@@ -6153,15 +6211,15 @@
           "$ref": "#/definitions/CommunityInfrastructureLevy"
         },
         "declaration": {
-          "$ref": "#/definitions/ApplicationDeclaration"
+          "$ref": "#/definitions/Declaration"
         },
         "fee": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ApplicationFee"
+              "$ref": "#/definitions/Fee"
             },
             {
-              "$ref": "#/definitions/ApplicationFeeNotApplicable"
+              "$ref": "#/definitions/FeeNotApplicable"
             }
           ]
         },
@@ -7682,52 +7740,7 @@
             "$ref": "#/definitions/Address"
           },
           "contact": {
-            "additionalProperties": false,
-            "properties": {
-              "company": {
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ],
-                "type": "object"
-              },
-              "email": {
-                "type": "string"
-              },
-              "name": {
-                "additionalProperties": false,
-                "properties": {
-                  "first": {
-                    "type": "string"
-                  },
-                  "last": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "first",
-                  "last"
-                ],
-                "type": "object"
-              },
-              "phone": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "email",
-              "phone"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/ContactDetails"
           },
           "when": {
             "enum": [
@@ -7935,7 +7948,7 @@
         },
         "pao": {
           "description": "Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties",
-          "title": "Primary Addressable Object start range and/or building description",
+          "title": "Primary Addressable Object (PAO) start range and/or building description",
           "type": "string"
         },
         "paoEnd": {
@@ -8347,7 +8360,6 @@
       "description": "Types of natural open spaces"
     },
     "Owners": {
-      "$id": "#Owners",
       "anyOf": [
         {
           "$ref": "#/definitions/OwnersNoticeGiven"
@@ -8359,7 +8371,17 @@
           "$ref": "#/definitions/OwnersNoticeDate"
         }
       ],
-      "description": "Names and addresses of all known owners and agricultural tenants, including confirmation or date of notice, or reason requisite notice has not been given if applicable"
+      "description": "Names and addresses of all known owners and agricultural tenants who are not the applicant, including confirmation or date of notice, or reason requisite notice has not been given if applicable",
+      "title": "#Owners"
+    },
+    "OwnersInterest": {
+      "enum": [
+        "owner",
+        "lessee",
+        "occupier",
+        "other"
+      ],
+      "type": "string"
     },
     "OwnersNoNoticeGiven": {
       "additionalProperties": false,
@@ -8375,13 +8397,7 @@
           ]
         },
         "interest": {
-          "enum": [
-            "owner",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -8416,13 +8432,7 @@
           ]
         },
         "interest": {
-          "enum": [
-            "owner",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -8452,13 +8462,7 @@
           ]
         },
         "interest": {
-          "enum": [
-            "owner",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -8476,7 +8480,6 @@
       "type": "object"
     },
     "Ownership": {
-      "$id": "#Ownership",
       "additionalProperties": false,
       "description": "Information about the ownership certificate and property owners, if different than the applicant",
       "properties": {
@@ -8508,15 +8511,19 @@
           "type": "object"
         },
         "interest": {
-          "enum": [
-            "owner",
-            "owner.sole",
-            "owner.co",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OwnersInterest"
+            },
+            {
+              "const": "owner.sole",
+              "type": "string"
+            },
+            {
+              "const": "owner.co",
+              "type": "string"
+            }
+          ]
         },
         "noticeGiven": {
           "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
@@ -8557,6 +8564,7 @@
           "type": "string"
         }
       },
+      "title": "#Ownership",
       "type": "object"
     },
     "PlanXMetadata": {
@@ -8648,7 +8656,6 @@
       "type": "object"
     },
     "PlanningConstraint": {
-      "$id": "#PlanningConstraint",
       "anyOf": [
         {
           "additionalProperties": false,
@@ -8702,7 +8709,8 @@
           "type": "object"
         }
       ],
-      "description": "Planning constraints that intersect with the proposed site"
+      "description": "Planning constraints that intersect with the proposed site",
+      "title": "#PlanningConstraint"
     },
     "PlanningDesignation": {
       "$id": "#PlanningDesignation",
@@ -25402,7 +25410,6 @@
       "type": "object"
     },
     "UserAddress": {
-      "$id": "#UserAddress",
       "anyOf": [
         {
           "additionalProperties": false,
@@ -25421,10 +25428,10 @@
           "$ref": "#/definitions/UserAddressNotSameSite"
         }
       ],
-      "description": "Address information for the applicant"
+      "description": "Address information for the applicant",
+      "title": "#UserAddress"
     },
     "UserAddressNotSameSite": {
-      "$id": "#UserAddressNotSameSite",
       "additionalProperties": false,
       "description": "Address information for an applicant with contact information that differs from the property address",
       "properties": {
@@ -25457,6 +25464,7 @@
         "sameAsSiteAddress",
         "town"
       ],
+      "title": "#UserAddressNotSameSite",
       "type": "object"
     }
   },

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -989,7 +989,7 @@
           "type": "object"
         },
         "boundary": {
-          "$ref": "#/definitions/GeoBoundaryPrototype",
+          "$ref": "#/definitions/GeoBoundary",
           "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary"
         },
         "date": {
@@ -1887,22 +1887,6 @@
       "description": "Tenure types tracked by the Greater London Authority (GLA)"
     },
     "GeoBoundary": {
-      "additionalProperties": false,
-      "properties": {
-        "area": {
-          "$ref": "#/definitions/Area"
-        },
-        "site": {
-          "$ref": "#/definitions/GeoJSON"
-        }
-      },
-      "required": [
-        "site",
-        "area"
-      ],
-      "type": "object"
-    },
-    "GeoBoundaryPrototype": {
       "additionalProperties": false,
       "properties": {
         "area": {
@@ -3154,7 +3138,7 @@
           "type": "object"
         },
         "boundary": {
-          "$ref": "#/definitions/GeoBoundaryPrototype",
+          "$ref": "#/definitions/GeoBoundary",
           "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary"
         },
         "charging": {
@@ -4464,7 +4448,7 @@
     },
     "OSAddress": {
       "additionalProperties": false,
-      "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium (LPI)",
+      "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium LPI source",
       "properties": {
         "latitude": {
           "description": "Latitude coordinate in EPSG:4326 (WGS84)",
@@ -4511,6 +4495,7 @@
           "type": "string"
         },
         "title": {
+          "description": "Single line address description",
           "type": "string"
         },
         "town": {
@@ -4550,6 +4535,7 @@
         "x",
         "y"
       ],
+      "title": "#OSAddress",
       "type": "object"
     },
     "OpenSpaceDesignation": {
@@ -10197,6 +10183,7 @@
           "type": "string"
         },
         "title": {
+          "description": "Single line address description",
           "type": "string"
         },
         "x": {
@@ -10216,6 +10203,7 @@
         "x",
         "y"
       ],
+      "title": "#ProposedAddress",
       "type": "object"
     },
     "ProtectedSpaceDesignation": {
@@ -10939,6 +10927,7 @@
         "South East",
         "South West"
       ],
+      "title": "#Region",
       "type": "string"
     },
     "ResidentialUnits": {

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -19,11 +19,41 @@
     }
   ],
   "definitions": {
+    "Address": {
+      "additionalProperties": false,
+      "description": "Address information for a person associated with this application not at the property address",
+      "properties": {
+        "country": {
+          "type": "string"
+        },
+        "county": {
+          "type": "string"
+        },
+        "line1": {
+          "type": "string"
+        },
+        "line2": {
+          "type": "string"
+        },
+        "postcode": {
+          "type": "string"
+        },
+        "town": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "line1",
+        "town",
+        "postcode"
+      ],
+      "type": "object"
+    },
     "Agent": {
       "additionalProperties": false,
       "properties": {
         "address": {
-          "$ref": "#/definitions/ApplicantAddress",
+          "$ref": "#/definitions/UserAddress",
           "description": "Address information for the applicant"
         },
         "agent": {
@@ -31,7 +61,7 @@
           "description": "Contact information for the agent or proxy",
           "properties": {
             "address": {
-              "$ref": "#/definitions/UserAddress"
+              "$ref": "#/definitions/Address"
             },
             "company": {
               "additionalProperties": false,
@@ -161,60 +191,6 @@
       ],
       "type": "object"
     },
-    "ApplicantAddress": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "sameAsSiteAddress": {
-              "const": true,
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "sameAsSiteAddress"
-          ],
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/ApplicantAddressNotSameSite"
-        }
-      ]
-    },
-    "ApplicantAddressNotSameSite": {
-      "additionalProperties": false,
-      "properties": {
-        "country": {
-          "type": "string"
-        },
-        "county": {
-          "type": "string"
-        },
-        "line1": {
-          "type": "string"
-        },
-        "line2": {
-          "type": "string"
-        },
-        "postcode": {
-          "type": "string"
-        },
-        "sameAsSiteAddress": {
-          "const": false,
-          "type": "boolean"
-        },
-        "town": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "line1",
-        "postcode",
-        "sameAsSiteAddress",
-        "town"
-      ],
-      "type": "object"
-    },
     "ApplicantBase": {
       "anyOf": [
         {
@@ -224,205 +200,6 @@
           "$ref": "#/definitions/Agent"
         }
       ]
-    },
-    "ApplicationDeclaration": {
-      "additionalProperties": false,
-      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
-      "properties": {
-        "accurate": {
-          "type": "boolean"
-        },
-        "connection": {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "type": "string"
-            },
-            "value": {
-              "enum": [
-                "employee",
-                "relation.employee",
-                "electedMember",
-                "relation.electedMember",
-                "none"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "value"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "accurate",
-        "connection"
-      ],
-      "type": "object"
-    },
-    "ApplicationFee": {
-      "additionalProperties": false,
-      "description": "The costs associated with this application",
-      "properties": {
-        "calculated": {
-          "description": "Total calculated fee in GBP",
-          "type": "number"
-        },
-        "category": {
-          "additionalProperties": false,
-          "description": "Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2",
-          "properties": {
-            "eight": {
-              "description": "Category 8 - Car parks or access roads",
-              "type": "number"
-            },
-            "eleven": {
-              "additionalProperties": false,
-              "properties": {
-                "one": {
-                  "description": "Category 11(1) - Mining operations",
-                  "type": "number"
-                },
-                "two": {
-                  "description": "Category 11(2) - Other operations",
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "five": {
-              "description": "Category 5 - Plant equipment or machinery",
-              "type": "number"
-            },
-            "four": {
-              "description": "Category 4 - Glasshouses on agricultural land",
-              "type": "number"
-            },
-            "fourteen": {
-              "description": "Category 14 - Other change of use",
-              "type": "number"
-            },
-            "nine": {
-              "description": "Category 9 - Exploratory drilling",
-              "type": "number"
-            },
-            "one": {
-              "description": "Category 1 - New homes",
-              "type": "number"
-            },
-            "sixAndSeven": {
-              "description": "Category 6 and 7 - Home or curtilage of home",
-              "type": "number"
-            },
-            "ten": {
-              "description": "Category 10 - Winning and working of oil or natural gas",
-              "type": "number"
-            },
-            "thirteen": {
-              "description": "Category 13 - Waste disposal",
-              "type": "number"
-            },
-            "three": {
-              "description": "Category 3 - Agricultural buildings",
-              "type": "number"
-            },
-            "twelve": {
-              "additionalProperties": false,
-              "properties": {
-                "one": {
-                  "description": "Category 12(1) - Change of use from single home to homes",
-                  "type": "number"
-                },
-                "two": {
-                  "description": "Category 12(2) - Change of use to home",
-                  "type": "number"
-                }
-              },
-              "type": "object"
-            },
-            "two": {
-              "description": "Category 2 - Other new buildings",
-              "type": "number"
-            }
-          },
-          "type": "object"
-        },
-        "exemption": {
-          "additionalProperties": false,
-          "properties": {
-            "disability": {
-              "type": "boolean"
-            },
-            "resubmission": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "disability",
-            "resubmission"
-          ],
-          "type": "object"
-        },
-        "payable": {
-          "description": "Total payable fee after any exemptions or reductions in GBP",
-          "type": "number"
-        },
-        "reduction": {
-          "additionalProperties": false,
-          "properties": {
-            "alternative": {
-              "type": "boolean"
-            },
-            "parishCouncil": {
-              "type": "boolean"
-            },
-            "sports": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "alternative",
-            "parishCouncil",
-            "sports"
-          ],
-          "type": "object"
-        },
-        "reference": {
-          "additionalProperties": false,
-          "properties": {
-            "govPay": {
-              "description": "GOV.UK Pay payment reference number",
-              "type": "string"
-            }
-          },
-          "required": [
-            "govPay"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "calculated",
-        "payable",
-        "exemption",
-        "reduction"
-      ],
-      "type": "object"
-    },
-    "ApplicationFeeNotApplicable": {
-      "additionalProperties": false,
-      "description": "An indicator that an application fee does not apply to this application type or journey",
-      "properties": {
-        "notApplicable": {
-          "const": true,
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "notApplicable"
-      ],
-      "type": "object"
     },
     "Area": {
       "$id": "#Area",
@@ -465,7 +242,7 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "$ref": "#/definitions/ApplicantAddress",
+          "$ref": "#/definitions/UserAddress",
           "description": "Address information for the applicant"
         },
         "company": {
@@ -762,6 +539,7 @@
     },
     "ContactDetails": {
       "additionalProperties": false,
+      "description": "Contact details for a person associated with this application",
       "properties": {
         "company": {
           "additionalProperties": false,
@@ -815,6 +593,7 @@
         "email",
         "phone"
       ],
+      "title": "#ContactDetails",
       "type": "object"
     },
     "Date": {
@@ -826,6 +605,43 @@
       "format": "date-time",
       "pattern": "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$",
       "type": "string"
+    },
+    "Declaration": {
+      "additionalProperties": false,
+      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
+      "properties": {
+        "accurate": {
+          "type": "boolean"
+        },
+        "connection": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "value": {
+              "enum": [
+                "employee",
+                "relation.employee",
+                "electedMember",
+                "relation.electedMember",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "accurate",
+        "connection"
+      ],
+      "title": "#Declaration",
+      "type": "object"
     },
     "DevelopmentType": {
       "$id": "#DevelopmentType",
@@ -1484,16 +1300,166 @@
       ],
       "type": "object"
     },
+    "Fee": {
+      "additionalProperties": false,
+      "description": "The costs associated with this application",
+      "properties": {
+        "calculated": {
+          "description": "Total calculated fee in GBP",
+          "type": "number"
+        },
+        "category": {
+          "additionalProperties": false,
+          "description": "Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2",
+          "properties": {
+            "eight": {
+              "description": "Category 8 - Car parks or access roads",
+              "type": "number"
+            },
+            "eleven": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "description": "Category 11(1) - Mining operations",
+                  "type": "number"
+                },
+                "two": {
+                  "description": "Category 11(2) - Other operations",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "five": {
+              "description": "Category 5 - Plant equipment or machinery",
+              "type": "number"
+            },
+            "four": {
+              "description": "Category 4 - Glasshouses on agricultural land",
+              "type": "number"
+            },
+            "fourteen": {
+              "description": "Category 14 - Other change of use",
+              "type": "number"
+            },
+            "nine": {
+              "description": "Category 9 - Exploratory drilling",
+              "type": "number"
+            },
+            "one": {
+              "description": "Category 1 - New homes",
+              "type": "number"
+            },
+            "sixAndSeven": {
+              "description": "Category 6 and 7 - Home or curtilage of home",
+              "type": "number"
+            },
+            "ten": {
+              "description": "Category 10 - Winning and working of oil or natural gas",
+              "type": "number"
+            },
+            "thirteen": {
+              "description": "Category 13 - Waste disposal",
+              "type": "number"
+            },
+            "three": {
+              "description": "Category 3 - Agricultural buildings",
+              "type": "number"
+            },
+            "twelve": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "description": "Category 12(1) - Change of use from single home to homes",
+                  "type": "number"
+                },
+                "two": {
+                  "description": "Category 12(2) - Change of use to home",
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "two": {
+              "description": "Category 2 - Other new buildings",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "exemption": {
+          "additionalProperties": false,
+          "properties": {
+            "disability": {
+              "type": "boolean"
+            },
+            "resubmission": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "disability",
+            "resubmission"
+          ],
+          "type": "object"
+        },
+        "payable": {
+          "description": "Total payable fee after any exemptions or reductions in GBP",
+          "type": "number"
+        },
+        "reduction": {
+          "additionalProperties": false,
+          "properties": {
+            "alternative": {
+              "type": "boolean"
+            },
+            "parishCouncil": {
+              "type": "boolean"
+            },
+            "sports": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "alternative",
+            "parishCouncil",
+            "sports"
+          ],
+          "type": "object"
+        },
+        "reference": {
+          "additionalProperties": false,
+          "properties": {
+            "govPay": {
+              "description": "GOV.UK Pay payment reference number",
+              "type": "string"
+            }
+          },
+          "required": [
+            "govPay"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "calculated",
+        "payable",
+        "exemption",
+        "reduction"
+      ],
+      "title": "#Fee",
+      "type": "object"
+    },
     "FeeCarryingApplicationData": {
       "anyOf": [
         {
           "additionalProperties": false,
           "properties": {
             "declaration": {
-              "$ref": "#/definitions/ApplicationDeclaration"
+              "$ref": "#/definitions/Declaration"
             },
             "fee": {
-              "$ref": "#/definitions/ApplicationFee"
+              "$ref": "#/definitions/Fee"
             },
             "planningApp": {
               "$ref": "#/definitions/PlanningApplication"
@@ -1512,10 +1478,10 @@
           "additionalProperties": false,
           "properties": {
             "declaration": {
-              "$ref": "#/definitions/ApplicationDeclaration"
+              "$ref": "#/definitions/Declaration"
             },
             "fee": {
-              "$ref": "#/definitions/ApplicationFee"
+              "$ref": "#/definitions/Fee"
             },
             "leadDeveloper": {
               "$ref": "#/definitions/LeadDeveloper"
@@ -1682,6 +1648,21 @@
       "required": [
         "notApplicable"
       ],
+      "type": "object"
+    },
+    "FeeNotApplicable": {
+      "additionalProperties": false,
+      "description": "An indicator that an application fee does not apply to this application type or journey",
+      "properties": {
+        "notApplicable": {
+          "const": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "notApplicable"
+      ],
+      "title": "#FeeNotApplicable",
       "type": "object"
     },
     "File": {
@@ -2047,7 +2028,7 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/ApplicantAddress",
+              "$ref": "#/definitions/UserAddress",
               "description": "Address information for the applicant"
             },
             "company": {
@@ -2103,7 +2084,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "interest": {
-                      "$ref": "#/definitions/OwnershipInterest"
+                      "$ref": "#/definitions/OwnersInterest"
                     },
                     "owners": {
                       "items": {
@@ -2171,7 +2152,7 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/ApplicantAddress",
+              "$ref": "#/definitions/UserAddress",
               "description": "Address information for the applicant"
             },
             "agent": {
@@ -2179,7 +2160,7 @@
               "description": "Contact information for the agent or proxy",
               "properties": {
                 "address": {
-                  "$ref": "#/definitions/UserAddress"
+                  "$ref": "#/definitions/Address"
                 },
                 "company": {
                   "additionalProperties": false,
@@ -2289,7 +2270,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "interest": {
-                      "$ref": "#/definitions/OwnershipInterest"
+                      "$ref": "#/definitions/OwnersInterest"
                     },
                     "owners": {
                       "items": {
@@ -2450,7 +2431,7 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/ApplicantAddress",
+              "$ref": "#/definitions/UserAddress",
               "description": "Address information for the applicant"
             },
             "company": {
@@ -2497,7 +2478,7 @@
                 "interest": {
                   "anyOf": [
                     {
-                      "$ref": "#/definitions/OwnershipInterest"
+                      "$ref": "#/definitions/OwnersInterest"
                     },
                     {
                       "const": "owner.sole",
@@ -2558,7 +2539,7 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/ApplicantAddress",
+              "$ref": "#/definitions/UserAddress",
               "description": "Address information for the applicant"
             },
             "agent": {
@@ -2566,7 +2547,7 @@
               "description": "Contact information for the agent or proxy",
               "properties": {
                 "address": {
-                  "$ref": "#/definitions/UserAddress"
+                  "$ref": "#/definitions/Address"
                 },
                 "company": {
                   "additionalProperties": false,
@@ -2667,7 +2648,7 @@
                 "interest": {
                   "anyOf": [
                     {
-                      "$ref": "#/definitions/OwnershipInterest"
+                      "$ref": "#/definitions/OwnersInterest"
                     },
                     {
                       "const": "owner.sole",
@@ -4210,7 +4191,7 @@
         "additionalProperties": false,
         "properties": {
           "address": {
-            "$ref": "#/definitions/UserAddress"
+            "$ref": "#/definitions/Address"
           },
           "contact": {
             "$ref": "#/definitions/ContactDetails"
@@ -4397,10 +4378,10 @@
           "additionalProperties": false,
           "properties": {
             "declaration": {
-              "$ref": "#/definitions/ApplicationDeclaration"
+              "$ref": "#/definitions/Declaration"
             },
             "fee": {
-              "$ref": "#/definitions/ApplicationFeeNotApplicable"
+              "$ref": "#/definitions/FeeNotApplicable"
             },
             "planningApp": {
               "$ref": "#/definitions/PlanningApplication"
@@ -4419,10 +4400,10 @@
           "additionalProperties": false,
           "properties": {
             "declaration": {
-              "$ref": "#/definitions/ApplicationDeclaration"
+              "$ref": "#/definitions/Declaration"
             },
             "fee": {
-              "$ref": "#/definitions/ApplicationFeeNotApplicable"
+              "$ref": "#/definitions/FeeNotApplicable"
             },
             "leadDeveloper": {
               "$ref": "#/definitions/LeadDeveloper"
@@ -4463,7 +4444,7 @@
         },
         "pao": {
           "description": "Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties",
-          "title": "Primary Addressable Object start range and/or building description",
+          "title": "Primary Addressable Object (PAO) start range and/or building description",
           "type": "string"
         },
         "paoEnd": {
@@ -4640,13 +4621,22 @@
       ],
       "description": "Types of natural open spaces"
     },
+    "OwnersInterest": {
+      "enum": [
+        "owner",
+        "lessee",
+        "occupier",
+        "other"
+      ],
+      "type": "string"
+    },
     "OwnersNoNoticeGiven": {
       "additionalProperties": false,
       "properties": {
         "address": {
           "anyOf": [
             {
-              "$ref": "#/definitions/UserAddress"
+              "$ref": "#/definitions/Address"
             },
             {
               "type": "string"
@@ -4654,7 +4644,7 @@
           ]
         },
         "interest": {
-          "$ref": "#/definitions/OwnershipInterest"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -4681,7 +4671,7 @@
         "address": {
           "anyOf": [
             {
-              "$ref": "#/definitions/UserAddress"
+              "$ref": "#/definitions/Address"
             },
             {
               "type": "string"
@@ -4689,7 +4679,7 @@
           ]
         },
         "interest": {
-          "$ref": "#/definitions/OwnershipInterest"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -4711,7 +4701,7 @@
         "address": {
           "anyOf": [
             {
-              "$ref": "#/definitions/UserAddress"
+              "$ref": "#/definitions/Address"
             },
             {
               "type": "string"
@@ -4719,7 +4709,7 @@
           ]
         },
         "interest": {
-          "$ref": "#/definitions/OwnershipInterest"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -4735,15 +4725,6 @@
         "noticeGiven"
       ],
       "type": "object"
-    },
-    "OwnershipInterest": {
-      "enum": [
-        "owner",
-        "lessee",
-        "occupier",
-        "other"
-      ],
-      "type": "string"
     },
     "PA": {
       "additionalProperties": false,
@@ -5083,7 +5064,7 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/ApplicantAddress",
+              "$ref": "#/definitions/UserAddress",
               "description": "Address information for the applicant"
             },
             "company": {
@@ -5158,7 +5139,7 @@
                 "interest": {
                   "anyOf": [
                     {
-                      "$ref": "#/definitions/OwnershipInterest"
+                      "$ref": "#/definitions/OwnersInterest"
                     },
                     {
                       "const": "owner.sole",
@@ -5259,7 +5240,7 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/ApplicantAddress",
+              "$ref": "#/definitions/UserAddress",
               "description": "Address information for the applicant"
             },
             "agent": {
@@ -5267,7 +5248,7 @@
               "description": "Contact information for the agent or proxy",
               "properties": {
                 "address": {
-                  "$ref": "#/definitions/UserAddress"
+                  "$ref": "#/definitions/Address"
                 },
                 "company": {
                   "additionalProperties": false,
@@ -5396,7 +5377,7 @@
                 "interest": {
                   "anyOf": [
                     {
-                      "$ref": "#/definitions/OwnershipInterest"
+                      "$ref": "#/definitions/OwnersInterest"
                     },
                     {
                       "const": "owner.sole",
@@ -5505,10 +5486,10 @@
               "$ref": "#/definitions/CommunityInfrastructureLevy"
             },
             "declaration": {
-              "$ref": "#/definitions/ApplicationDeclaration"
+              "$ref": "#/definitions/Declaration"
             },
             "fee": {
-              "$ref": "#/definitions/ApplicationFee"
+              "$ref": "#/definitions/Fee"
             },
             "planningApp": {
               "$ref": "#/definitions/PlanningApplication"
@@ -5530,10 +5511,10 @@
               "$ref": "#/definitions/CommunityInfrastructureLevy"
             },
             "declaration": {
-              "$ref": "#/definitions/ApplicationDeclaration"
+              "$ref": "#/definitions/Declaration"
             },
             "fee": {
-              "$ref": "#/definitions/ApplicationFee"
+              "$ref": "#/definitions/Fee"
             },
             "leadDeveloper": {
               "$ref": "#/definitions/LeadDeveloper"
@@ -11147,7 +11128,30 @@
       "type": "string"
     },
     "UserAddress": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "sameAsSiteAddress": {
+              "const": true,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "sameAsSiteAddress"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/UserAddressNotSameSite"
+        }
+      ],
+      "description": "Address information for the applicant",
+      "title": "#UserAddress"
+    },
+    "UserAddressNotSameSite": {
       "additionalProperties": false,
+      "description": "Address information for an applicant with contact information that differs from the property address",
       "properties": {
         "country": {
           "type": "string"
@@ -11164,15 +11168,21 @@
         "postcode": {
           "type": "string"
         },
+        "sameAsSiteAddress": {
+          "const": false,
+          "type": "boolean"
+        },
         "town": {
           "type": "string"
         }
       },
       "required": [
         "line1",
-        "town",
-        "postcode"
+        "postcode",
+        "sameAsSiteAddress",
+        "town"
       ],
+      "title": "#UserAddressNotSameSite",
       "type": "object"
     },
     "UserBase": {

--- a/types/schemas/application/data/Applicant.ts
+++ b/types/schemas/application/data/Applicant.ts
@@ -1,4 +1,6 @@
-import {Date, Email} from '../../../shared/utils';
+import {Address, UserAddress} from '../../../shared/Addresses';
+import {ContactDetails} from '../../../shared/Contacts';
+import {Ownership} from '../../../shared/Ownership';
 import {User} from './User';
 
 /**
@@ -11,142 +13,20 @@ export type Applicant = BaseApplicant | Agent;
  * @id #BaseApplicant
  * @description Information about the user who completed the application for themself, or information about the person who the user applied on behalf of
  */
-export interface BaseApplicant {
+export type BaseApplicant = ContactDetails & {
   type: 'individual' | 'company' | 'charity' | 'public' | 'parishCouncil';
-  name: {
-    title?: string;
-    first: string;
-    last: string;
-  };
-  email: Email;
-  phone: {
-    primary: string;
-  };
-  company?: {
-    name: string;
-  };
   address: UserAddress;
   ownership?: Ownership;
   siteContact: SiteContact;
   maintenanceContact?: MaintenanceContact;
-}
-
-/**
- * @id #Ownership
- * @description Information about the ownership certificate and property owners, if different than the applicant
- */
-export interface Ownership {
-  interest?:
-    | 'owner'
-    | 'owner.sole'
-    | 'owner.co'
-    | 'lessee'
-    | 'occupier'
-    | 'other';
-  certificate?: 'a' | 'b' | 'c' | 'd';
-  /**
-   * @description Does the land have any agricultural tenants?
-   */
-  agriculturalTenants?: boolean;
-  /**
-   * @description Has requisite notice been given to all the known owners and agricultural tenants?
-   */
-  noticeGiven?: boolean;
-  /**
-   * @description Has a notice of the application been published in a newspaper circulating in the area where the land is situated?
-   */
-  noticePublished?: {
-    status: boolean;
-    date?: Date;
-    newspaperName?: string;
-  };
-  /**
-   * @description Do you know the names and addresses of all owners and agricultural tenants?
-   */
-  ownersKnown?: 'all' | 'some' | 'none';
-  owners?: Owners[];
-  /**
-   * @description Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice
-   */
-  declaration?: {
-    accurate: true;
-  };
-}
-
-/**
- * @id #Owners
- * @description Names and addresses of all known owners and agricultural tenants, including confirmation or date of notice, or reason requisite notice has not been given if applicable
- */
-export type Owners = OwnersNoticeGiven | OwnersNoNoticeGiven | OwnersNoticeDate;
-
-export interface BaseOwners {
-  name: string;
-  address: Address | string;
-  interest?: 'owner' | 'lessee' | 'occupier' | 'other';
-}
-
-// LDC requires `noticeGiven`, and `noNoticeReason` if false
-export interface OwnersNoticeGiven extends BaseOwners {
-  noticeGiven: true;
-}
-
-export interface OwnersNoNoticeGiven extends BaseOwners {
-  noticeGiven: false;
-  noNoticeReason: string;
-}
-
-// PP & LBC require `noticeDate`
-export interface OwnersNoticeDate extends BaseOwners {
-  noticeDate: Date;
-}
+};
 
 /**
  * @id #Agent
  * @description Information about the agent or proxy who completed the application on behalf of someone else
  */
 export interface Agent extends BaseApplicant {
-  agent: {
-    name: {
-      title?: string;
-      first: string;
-      last: string;
-    };
-    email: Email;
-    phone: {
-      primary: string;
-    };
-    company?: {
-      name: string;
-    };
-    address: Address;
-  };
-}
-
-/**
- * @id #Address
- * @description Address information for a person associated with this application not at the property address
- */
-export interface Address {
-  line1: string;
-  line2?: string;
-  town: string;
-  county?: string;
-  postcode: string;
-  country?: string;
-}
-
-/**
- * @id #UserAddress
- * @description Address information for the applicant
- */
-export type UserAddress = {sameAsSiteAddress: true} | UserAddressNotSameSite;
-
-/**
- * @id #UserAddressNotSameSite
- * @description Address information for an applicant with contact information that differs from the property address
- */
-export interface UserAddressNotSameSite extends Address {
-  sameAsSiteAddress: false;
+  agent: ContactDetails & {address: Address};
 }
 
 /**
@@ -176,16 +56,5 @@ export type MaintenanceContact = {
     | 'afterConstruction'
     | 'duringAndAfterConstruction';
   address: Address;
-  contact: {
-    name: {
-      title?: string;
-      first: string;
-      last: string;
-    };
-    email: string;
-    phone: string;
-    company?: {
-      name: string;
-    };
-  };
+  contact: ContactDetails;
 }[];

--- a/types/schemas/application/data/ApplicationData.ts
+++ b/types/schemas/application/data/ApplicationData.ts
@@ -1,5 +1,7 @@
-import {ApplicationType} from '../enums/ApplicationTypes';
+import {Declaration} from '../../../shared/Declarations';
 import {Date} from '../../../shared/utils';
+import {ApplicationType} from '../enums/ApplicationTypes';
+import {Fee, FeeNotApplicable} from '../../../shared/Fees';
 
 /**
  * @id #ApplicationData
@@ -9,8 +11,8 @@ export type ApplicationData = BaseApplicationData | LondonApplicationData;
 
 export interface BaseApplicationData {
   type: ApplicationType;
-  fee: ApplicationFee | ApplicationFeeNotApplicable;
-  declaration: ApplicationDeclaration;
+  fee: Fee | FeeNotApplicable;
+  declaration: Declaration;
   preApp?: PreApplication;
   planningApp?: PlanningApplication;
   CIL?: CommunityInfrastructureLevy;
@@ -23,130 +25,6 @@ export interface BaseApplicationData {
 export interface LondonApplicationData extends BaseApplicationData {
   vacantBuildingCredit?: boolean;
   leadDeveloper?: LeadDeveloper;
-}
-
-/**
- * @id #ApplicationFeeNotApplicable
- * @description An indicator that an application fee does not apply to this application type or journey
- */
-export interface ApplicationFeeNotApplicable {
-  notApplicable: true;
-}
-
-/**
- * @id #ApplicationFee
- * @description The costs associated with this application
- */
-export interface ApplicationFee {
-  /**
-   * @description Total calculated fee in GBP
-   */
-  calculated: number;
-  /**
-   * @description Total payable fee after any exemptions or reductions in GBP
-   */
-  payable: number;
-  /**
-   * @description Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2
-   */
-  category?: {
-    /**
-     * @description Category 1 - New homes
-     */
-    one?: number;
-    /**
-     * @description Category 2 - Other new buildings
-     */
-    two?: number;
-    /**
-     * @description Category 3 - Agricultural buildings
-     */
-    three?: number;
-    /**
-     * @description Category 4 - Glasshouses on agricultural land
-     */
-    four?: number;
-    /**
-     * @description Category 5 - Plant equipment or machinery
-     */
-    five?: number;
-    /**
-     * @description Category 6 and 7 - Home or curtilage of home
-     */
-    sixAndSeven?: number;
-    /**
-     * @description Category 8 - Car parks or access roads
-     */
-    eight?: number;
-    /**
-     * @description Category 9 - Exploratory drilling
-     */
-    nine?: number;
-    /**
-     * @description Category 10 - Winning and working of oil or natural gas
-     */
-    ten?: number;
-    eleven?: {
-      /**
-       * @description Category 11(1) - Mining operations
-       */
-      one?: number;
-      /**
-       * @description Category 11(2) - Other operations
-       */
-      two?: number;
-    };
-    twelve?: {
-      /**
-       * @description Category 12(1) - Change of use from single home to homes
-       */
-      one?: number;
-      /**
-       * @description Category 12(2) - Change of use to home
-       */
-      two?: number;
-    };
-    /**
-     * @description Category 13 - Waste disposal
-     */
-    thirteen?: number;
-    /**
-     * @description Category 14 - Other change of use
-     */
-    fourteen?: number;
-  };
-  exemption: {
-    disability: boolean; // @todo add application.fee.exemption.disability.reason
-    resubmission: boolean; // @todo add application.resubmission.original.applicationReference & application.resubmission.originalReference.appeal
-  };
-  reduction: {
-    alternative: boolean;
-    parishCouncil: boolean;
-    sports: boolean;
-  };
-  reference?: {
-    /**
-     * @description GOV.UK Pay payment reference number
-     */
-    govPay: string; // @todo require when payable > 0
-  };
-}
-
-/**
- * @id #ApplicationDeclaration
- * @description Declarations about the accuracy of this application and any personal connections to the receiving authority
- */
-export interface ApplicationDeclaration {
-  accurate: boolean;
-  connection: {
-    value:
-      | 'employee'
-      | 'relation.employee'
-      | 'electedMember'
-      | 'relation.electedMember'
-      | 'none';
-    description?: string;
-  };
 }
 
 /**

--- a/types/schemas/application/data/Files.ts
+++ b/types/schemas/application/data/Files.ts
@@ -1,4 +1,4 @@
-import {GeoBoundary} from './shared';
+import {GeoBoundary} from './../../../shared/Boundaries';
 
 /**
  * @id #FilesAsData

--- a/types/schemas/application/data/Property.ts
+++ b/types/schemas/application/data/Property.ts
@@ -1,11 +1,12 @@
 import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
-import {GeoBoundary} from './../../../shared/Boundaries';
+import {PlanningConstraint} from '../../../shared/Constraints';
 import {Materials} from '../../../shared/Materials';
 import {Region} from '../../../shared/Regions';
 import {Date, URL} from '../../../shared/utils';
 import {PlanningDesignation} from '../enums/PlanningConstraints';
 import {PropertyType} from '../enums/PropertyTypes';
-import {Entity, ResidentialUnits} from './shared';
+import {GeoBoundary} from './../../../shared/Boundaries';
+import {ResidentialUnits} from './shared';
 
 /**
  * @id #Property
@@ -126,31 +127,3 @@ export interface LondonProperty extends UKProperty {
 }
 
 type ExistingCount = {count: number};
-
-type BasePlanningConstraint = {
-  value: string;
-  description: string;
-};
-
-/**
- * @description A planning constraint that does not intersect with the proposed site, per the DE-9IM spatial relationship definition of intersects
- */
-type NonIntersectingPlanningConstraint = {
-  intersects: false;
-} & BasePlanningConstraint;
-
-/**
- * @description A planning constraint that does intersect with the proposed site, per the DE-9IM spatial relationship definition of intersects
- */
-type IntersectingPlanningConstraint = {
-  intersects: true;
-  entities: Entity[];
-} & BasePlanningConstraint;
-
-/**
- * @id #PlanningConstraint
- * @description Planning constraints that intersect with the proposed site
- */
-export type PlanningConstraint =
-  | NonIntersectingPlanningConstraint
-  | IntersectingPlanningConstraint;

--- a/types/schemas/application/data/Property.ts
+++ b/types/schemas/application/data/Property.ts
@@ -1,7 +1,11 @@
+import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
+import {GeoBoundary} from './../../../shared/Boundaries';
+import {Materials} from '../../../shared/Materials';
+import {Region} from '../../../shared/Regions';
+import {Date, URL} from '../../../shared/utils';
 import {PlanningDesignation} from '../enums/PlanningConstraints';
 import {PropertyType} from '../enums/PropertyTypes';
-import {Date, URL} from '../../../shared/utils';
-import {Entity, GeoBoundary, Materials, ResidentialUnits} from './shared';
+import {Entity, ResidentialUnits} from './shared';
 
 /**
  * @id #Property
@@ -10,27 +14,12 @@ import {Entity, GeoBoundary, Materials, ResidentialUnits} from './shared';
 export type Property = UKProperty | LondonProperty;
 
 /**
- * @id #UKRegion
- * @description The UK region that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area
- */
-export type UKRegion =
-  | 'North East'
-  | 'North West'
-  | 'Yorkshire and The Humber'
-  | 'East Midlands'
-  | 'West Midlands'
-  | 'East of England'
-  | 'London'
-  | 'South East'
-  | 'South West';
-
-/**
  * @id #UKProperty
  * @description Property details for sites anywhere in the UK
  */
 export interface UKProperty {
   address: ProposedAddress | OSAddress;
-  region: UKRegion;
+  region: Region;
   /**
    * @description Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
    */
@@ -91,7 +80,7 @@ export interface UKProperty {
  * @description Property details for sites within the Greater London Authority (GLA) area
  */
 export interface LondonProperty extends UKProperty {
-  region: Extract<UKRegion, 'London'>;
+  region: Extract<Region, 'London'>;
   titleNumber?: {
     known: 'Yes' | 'No';
     number?: string;
@@ -137,81 +126,6 @@ export interface LondonProperty extends UKProperty {
 }
 
 type ExistingCount = {count: number};
-
-/**
- * @id #SiteAddress
- * @description Address information available for any site, whether existing or proposed
- */
-export interface SiteAddress {
-  title: string;
-  /**
-   * @description Easting coordinate in British National Grid (OSGB36)
-   */
-  x: number;
-  /**
-   * @description Northing coordinate in British National Grid (OSGB36)
-   */
-  y: number;
-  /**
-   * @description Latitude coordinate in EPSG:4326 (WGS84)
-   */
-  latitude: number;
-  /**
-   * @description Longitude coordinate in EPSG:4326 (WGS84)
-   */
-  longitude: number;
-}
-
-/**
- * @id #ProposedAddress
- * @description Address information for sites without a known Unique Property Reference Number (UPRN)
- */
-export interface ProposedAddress extends SiteAddress {
-  source: 'Proposed by applicant';
-}
-
-/**
- * @id #OSAddress
- * @description Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium
- */
-export interface OSAddress extends SiteAddress {
-  /**
-   * @title Unique Property Reference Number
-   * @maxLength 12
-   */
-  uprn: string;
-  /**
-   * @title Unique Street Reference Number
-   * @maxLength 8
-   */
-  usrn: string;
-  /**
-   * @title Primary Addressable Object start range and/or building description
-   * @description Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties
-   */
-  pao: string;
-  /**
-   * @title Primary Addressable Object (PAO) end range
-   * @description Combined `PAO_END_NUMBER`, `PAO_END_SUFFIX` OS LPI properties
-   */
-  paoEnd?: string;
-  /**
-   * @title Secondary Addressable Object (SAO) start range and/or building description
-   * @description Combined `SAO_START_NUMBER`, `SAO_START_SUFFIX`, `SAO_TEXT` OS LPI properties
-   */
-  sao?: string;
-  /**
-   * @title Secondary Addressable Object (SAO) end range
-   * @description Combined `SAO_END_NUMBER`, `SAO_END_SUFFIX` OS LPI properties
-   */
-  saoEnd?: string;
-  street: string;
-  town: string;
-  postcode: string;
-  organisation?: string;
-  singleLine: string;
-  source: 'Ordnance Survey';
-}
 
 type BasePlanningConstraint = {
   value: string;

--- a/types/schemas/application/data/Proposal.ts
+++ b/types/schemas/application/data/Proposal.ts
@@ -1,3 +1,5 @@
+import {GeoBoundary} from './../../../shared/Boundaries';
+import {Materials} from '../../../shared/Materials';
 import {BuildingRegulation} from '../enums/BuildingRegulations';
 import {DevelopmentType} from '../enums/DevelopmentTypes';
 import {GLAHousingProvider} from '../enums/HousingProviders';
@@ -7,7 +9,7 @@ import {ProtectedSpaceDesignation} from '../enums/ProtectedSpaces';
 import {GLAResidentialUnitType} from '../enums/ResidentialUnitTypes';
 import {GLATenureType} from '../enums/TenureTypes';
 import {Area, Date} from '../../../shared/utils';
-import {GeoBoundary, Materials, ResidentialUnits} from './shared';
+import {ResidentialUnits} from './shared';
 
 /**
  * @id #Proposal

--- a/types/schemas/application/data/shared.ts
+++ b/types/schemas/application/data/shared.ts
@@ -1,21 +1,5 @@
-import {URL} from '../../../shared/utils';
 import {UKResidentialUnitType} from '../enums/ResidentialUnitTypes';
 import {UKTenureType} from '../enums/TenureTypes';
-
-export type Entity = {
-  name: string;
-  description?: string;
-  source: PlanningDataSource | OSRoadsSource;
-};
-
-type PlanningDataSource = {
-  text: 'Planning Data';
-  url: URL;
-};
-
-type OSRoadsSource = {
-  text: 'Ordnance Survey MasterMap Highways';
-};
 
 export type ResidentialUnits = {
   total: number;

--- a/types/schemas/application/data/shared.ts
+++ b/types/schemas/application/data/shared.ts
@@ -1,23 +1,6 @@
-import {GeoJSON} from 'geojson';
+import {URL} from '../../../shared/utils';
 import {UKResidentialUnitType} from '../enums/ResidentialUnitTypes';
 import {UKTenureType} from '../enums/TenureTypes';
-import {Area, URL} from '../../../shared/utils';
-
-export type Materials = {
-  boundary?: string;
-  door?: string;
-  lighting?: string;
-  roof?: string;
-  surface?: string;
-  wall?: string;
-  window?: string;
-  other?: string;
-};
-
-export type GeoBoundary = {
-  site: GeoJSON;
-  area: Area;
-};
 
 export type Entity = {
   name: string;

--- a/types/schemas/application/enums/PlanningConstraints.ts
+++ b/types/schemas/application/enums/PlanningConstraints.ts
@@ -1,4 +1,4 @@
-import {Entity} from '../data/shared';
+import {Entity} from '../../../shared/Constraints';
 
 /**
  * Values for `data.property.planning.designations`

--- a/types/schemas/preApplication/data/Applicant.ts
+++ b/types/schemas/preApplication/data/Applicant.ts
@@ -1,9 +1,6 @@
-import {Email} from '../../../shared/utils';
-import {
-  Agent,
-  SiteContact,
-  UserAddress,
-} from '../../application/data/Applicant';
+import {UserAddress} from '../../../shared/Addresses';
+import {ContactDetails} from '../../../shared/Contacts';
+import {Agent, SiteContact} from '../../application/data/Applicant';
 
 /**
  * @id #Applicant
@@ -15,20 +12,8 @@ export type Applicant = BaseApplicant | Agent;
  * @id #BaseApplicant
  * @description Information about the user who completed the application for themself, or information about the person who the user applied on behalf of
  */
-export interface BaseApplicant {
+export type BaseApplicant = ContactDetails & {
   type: 'individual' | 'company' | 'charity' | 'public' | 'parishCouncil';
-  name: {
-    title?: string;
-    first: string;
-    last: string;
-  };
-  email: Email;
-  phone: {
-    primary: string;
-  };
-  company?: {
-    name: string;
-  };
   address: UserAddress;
   siteContact: SiteContact;
-}
+};

--- a/types/schemas/preApplication/data/ApplicationData.ts
+++ b/types/schemas/preApplication/data/ApplicationData.ts
@@ -1,23 +1,13 @@
-import {ApplicationDeclaration} from '../../application/data/ApplicationData';
+import {Declaration} from '../../../shared/Declarations';
+import {Fee} from '../../../shared/Fees';
 
 /**
  * @id #PreApplicationData
  * @description Information about this planning pre-application
  */
 export interface PreApplicationData {
-  fee: {
-    /**
-     * @description Total payable fee in GBP
-     */
-    payable: number;
-    reference: {
-      /**
-       * @description GOV.UK Pay payment reference number
-       */
-      govPay: string;
-    };
-  };
-  declaration: ApplicationDeclaration;
+  fee: Pick<Fee, 'payable' | 'reference'>;
+  declaration: Declaration;
   information: {
     harmful: {
       /**

--- a/types/schemas/preApplication/data/Property.ts
+++ b/types/schemas/preApplication/data/Property.ts
@@ -1,16 +1,13 @@
-import {
-  OSAddress,
-  ProposedAddress,
-  UKRegion,
-} from '../../application/data/Property';
-import {GeoBoundary} from '../../application/data/shared';
+import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
+import {GeoBoundary} from './../../../shared/Boundaries';
+import {Region} from '../../../shared/Regions';
+import {URL} from '../../../shared/utils';
 import {PlanningDesignation} from '../../application/enums/PlanningConstraints';
 import {PropertyType} from '../../prototypeApplication/enums/PropertyTypes';
-import {URL} from '../../../shared/utils';
 
 export interface Property {
   address: ProposedAddress | OSAddress;
-  region: UKRegion;
+  region: Region;
   /**
    * @description Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
    */

--- a/types/schemas/preApplication/data/Proposal.ts
+++ b/types/schemas/preApplication/data/Proposal.ts
@@ -1,4 +1,4 @@
-import {GeoBoundary} from '../../application/data/shared';
+import {GeoBoundary} from './../../../shared/Boundaries';
 
 export interface Proposal {
   description: string;

--- a/types/schemas/prototypeApplication/data/Applicant.ts
+++ b/types/schemas/prototypeApplication/data/Applicant.ts
@@ -1,4 +1,12 @@
-import {Date, Email} from '../../../shared/utils';
+import {Address, UserAddress} from '../../../shared/Addresses';
+import {ContactDetails} from '../../../shared/Contacts';
+import {
+  OwnersInterest,
+  OwnersNoNoticeGiven,
+  OwnersNoticeDate,
+  OwnersNoticeGiven,
+} from '../../../shared/Ownership';
+import {Date} from '../../../shared/utils';
 import {PrimaryApplicationType} from '../enums/ApplicationType';
 import {UserRoles} from './User';
 
@@ -12,7 +20,7 @@ export type BaseApplicant = ContactDetails & {
   /**
    * @description Address information for the applicant
    */
-  address: ApplicantAddress;
+  address: UserAddress;
   /**
    * @description Contact information for the site visit
    */
@@ -23,7 +31,7 @@ export interface Agent extends BaseApplicant {
   /**
    * @description Contact information for the agent or proxy
    */
-  agent: ContactDetails & {address: UserAddress};
+  agent: ContactDetails & {address: Address};
 }
 
 export type SiteContact = {role: UserRoles} | SiteContactOther;
@@ -35,65 +43,12 @@ export interface SiteContactOther {
   phone: string;
 }
 
-export type ContactDetails = {
-  name: {
-    title?: string;
-    first: string;
-    last: string;
-  };
-  email: Email;
-  phone: {
-    primary: string;
-  };
-  company?: {
-    name: string;
-  };
-};
-
-export type UserAddress = {
-  line1: string;
-  line2?: string;
-  town: string;
-  county?: string;
-  postcode: string;
-  country?: string;
-};
-
-export type ApplicantAddress =
-  | {sameAsSiteAddress: true}
-  | ApplicantAddressNotSameSite;
-
-export interface ApplicantAddressNotSameSite extends UserAddress {
-  sameAsSiteAddress: false;
-}
-
-export type OwnershipInterest = 'owner' | 'lessee' | 'occupier' | 'other';
-
-export interface BaseOwners {
-  name: string;
-  address: UserAddress | string;
-  interest?: OwnershipInterest;
-}
-
-export interface OwnersNoticeGiven extends BaseOwners {
-  noticeGiven: true;
-}
-
-export interface OwnersNoNoticeGiven extends BaseOwners {
-  noticeGiven: false;
-  noNoticeReason: string;
-}
-
-export interface OwnersNoticeDate extends BaseOwners {
-  noticeDate: Date;
-}
-
 export type MaintenanceContacts = {
   when:
     | 'duringConstruction'
     | 'afterConstruction'
     | 'duringAndAfterConstruction';
-  address: UserAddress;
+  address: Address;
   contact: ContactDetails;
 }[];
 
@@ -102,9 +57,9 @@ export type LDCApplicant = ApplicantBase & {
    * @description Information about the property owners, if different than the applicant
    */
   ownership:
-    | {interest: Extract<OwnershipInterest, 'owner'>}
+    | {interest: Extract<OwnersInterest, 'owner'>}
     | {
-        interest: OwnershipInterest; // `Exclude<OwnershipInterest, "owner">` ? But I think you can be co owner & report other owners?
+        interest: OwnersInterest; // `Exclude<OwnershipInterest, "owner">` ? But I think you can be co owner & report other owners?
         owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];
       };
 };
@@ -114,7 +69,7 @@ export type PPApplicant = ApplicantBase & {
    * @description Information about the ownership certificate and property owners, if different than the applicant
    */
   ownership: {
-    interest: OwnershipInterest | 'owner.sole' | 'owner.co';
+    interest: OwnersInterest | 'owner.sole' | 'owner.co';
     /**
      * @description Does the land have any agricultural tenants?
      */
@@ -152,7 +107,7 @@ export type PPApplicant = ApplicantBase & {
 
 export type LandDrainageConsentApplicant = ApplicantBase & {
   ownership: {
-    interest: OwnershipInterest | 'owner.sole' | 'owner.co';
+    interest: OwnersInterest | 'owner.sole' | 'owner.co';
   };
   /** @description Contact information for the person(s) responsible for maintenace while the works are carried out */
   maintenanceContact?: MaintenanceContacts;

--- a/types/schemas/prototypeApplication/data/ApplicationData.ts
+++ b/types/schemas/prototypeApplication/data/ApplicationData.ts
@@ -1,5 +1,7 @@
 import {PrimaryApplicationType} from '../enums/ApplicationType';
 import {Date} from '../../../shared/utils';
+import {Declaration} from '../../../shared/Declarations';
+import {Fee, FeeNotApplicable} from '../../../shared/Fees';
 
 /**
  * Base type for ApplicationData. Contains all shared properties across all application types
@@ -9,130 +11,9 @@ export type ApplicationDataBase =
   | LondonApplicationData;
 
 export interface EnglandApplicationData {
-  declaration: ApplicationDeclaration;
+  declaration: Declaration;
   preApp?: PreApplication;
   planningApp?: PlanningApplication;
-}
-
-/**
- * @description An indicator that an application fee does not apply to this application type or journey
- */
-export interface ApplicationFeeNotApplicable {
-  notApplicable: true;
-}
-
-/**
- * @description The costs associated with this application
- */
-export interface ApplicationFee {
-  /**
-   * @description Total calculated fee in GBP
-   */
-  calculated: number;
-  /**
-   * @description Total payable fee after any exemptions or reductions in GBP
-   */
-  payable: number;
-  /**
-   * @description Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2
-   */
-  category?: {
-    /**
-     * @description Category 1 - New homes
-     */
-    one?: number;
-    /**
-     * @description Category 2 - Other new buildings
-     */
-    two?: number;
-    /**
-     * @description Category 3 - Agricultural buildings
-     */
-    three?: number;
-    /**
-     * @description Category 4 - Glasshouses on agricultural land
-     */
-    four?: number;
-    /**
-     * @description Category 5 - Plant equipment or machinery
-     */
-    five?: number;
-    /**
-     * @description Category 6 and 7 - Home or curtilage of home
-     */
-    sixAndSeven?: number;
-    /**
-     * @description Category 8 - Car parks or access roads
-     */
-    eight?: number;
-    /**
-     * @description Category 9 - Exploratory drilling
-     */
-    nine?: number;
-    /**
-     * @description Category 10 - Winning and working of oil or natural gas
-     */
-    ten?: number;
-    eleven?: {
-      /**
-       * @description Category 11(1) - Mining operations
-       */
-      one?: number;
-      /**
-       * @description Category 11(2) - Other operations
-       */
-      two?: number;
-    };
-    twelve?: {
-      /**
-       * @description Category 12(1) - Change of use from single home to homes
-       */
-      one?: number;
-      /**
-       * @description Category 12(2) - Change of use to home
-       */
-      two?: number;
-    };
-    /**
-     * @description Category 13 - Waste disposal
-     */
-    thirteen?: number;
-    /**
-     * @description Category 14 - Other change of use
-     */
-    fourteen?: number;
-  };
-  exemption: {
-    disability: boolean; // @todo add application.fee.exemption.disability.reason
-    resubmission: boolean; // @todo add application.resubmission.original.applicationReference & application.resubmission.originalReference.appeal
-  };
-  reduction: {
-    alternative: boolean;
-    parishCouncil: boolean;
-    sports: boolean;
-  };
-  reference?: {
-    /**
-     * @description GOV.UK Pay payment reference number
-     */
-    govPay: string; // @todo require when payable > 0
-  };
-}
-
-/**
- * @description Declarations about the accuracy of this application and any personal connections to the receiving authority
- */
-export interface ApplicationDeclaration {
-  accurate: boolean;
-  connection: {
-    value:
-      | 'employee'
-      | 'relation.employee'
-      | 'electedMember'
-      | 'relation.electedMember'
-      | 'none';
-    description?: string;
-  };
 }
 
 /**
@@ -187,14 +68,14 @@ export interface LondonApplicationData extends EnglandApplicationData {
  * @description ApplicationData required for fee carrying application types
  */
 export type FeeCarryingApplicationData = ApplicationDataBase & {
-  fee: ApplicationFee;
+  fee: Fee;
 };
 
 /**
  * @description ApplicationData required for application types that do not have a fee
  */
 export type NonFeeCarryingApplicationData = ApplicationDataBase & {
-  fee: ApplicationFeeNotApplicable;
+  fee: FeeNotApplicable;
 };
 
 /**

--- a/types/schemas/prototypeApplication/data/Property.ts
+++ b/types/schemas/prototypeApplication/data/Property.ts
@@ -1,28 +1,16 @@
+import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
+import {GeoBoundary} from './../../../shared/Boundaries';
+import {Materials} from '../../../shared/Materials';
+import {Region} from '../../../shared/Regions';
 import {URL} from '../../../shared/utils';
-import {GeoBoundary} from '../../application/data/shared';
 import {PrimaryApplicationType} from '../enums/ApplicationType';
 import {
   PlanningConstraint,
   PlanningDesignation,
 } from '../enums/PlanningDesignation';
 import {PropertyType} from '../enums/PropertyTypes';
-import {Materials} from './shared';
 
 export type PropertyBase = EnglandProperty | LondonProperty;
-
-/**
- * @description The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area
- */
-export type Region =
-  | 'North East'
-  | 'North West'
-  | 'Yorkshire and The Humber'
-  | 'East Midlands'
-  | 'West Midlands'
-  | 'East of England'
-  | 'London'
-  | 'South East'
-  | 'South West';
 
 /**
  * @description Property details for sites anywhere in England
@@ -91,78 +79,6 @@ export interface LondonProperty extends EnglandProperty {
 }
 
 type ExistingCount = {count: number};
-
-/**
- * @description Address information available for any site, whether existing or proposed
- */
-export interface SiteAddress {
-  title: string;
-  /**
-   * @description Easting coordinate in British National Grid (OSGB36)
-   */
-  x: number;
-  /**
-   * @description Northing coordinate in British National Grid (OSGB36)
-   */
-  y: number;
-  /**
-   * @description Latitude coordinate in EPSG:4326 (WGS84)
-   */
-  latitude: number;
-  /**
-   * @description Longitude coordinate in EPSG:4326 (WGS84)
-   */
-  longitude: number;
-}
-
-/**
- * @description Address information for sites without a known Unique Property Reference Number (UPRN)
- */
-export interface ProposedAddress extends SiteAddress {
-  source: 'Proposed by applicant';
-}
-
-/**
- * @description Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium (LPI)
- */
-export interface OSAddress extends SiteAddress {
-  /**
-   * @title Unique Property Reference Number
-   * @maxLength 12
-   */
-  uprn: string;
-  /**
-   * @title Unique Street Reference Number
-   * @maxLength 8
-   */
-  usrn: string;
-  /**
-   * @title Primary Addressable Object start range and/or building description
-   * @description Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties
-   */
-  pao: string;
-  /**
-   * @title Primary Addressable Object (PAO) end range
-   * @description Combined `PAO_END_NUMBER`, `PAO_END_SUFFIX` OS LPI properties
-   */
-  paoEnd?: string;
-  /**
-   * @title Secondary Addressable Object (SAO) start range and/or building description
-   * @description Combined `SAO_START_NUMBER`, `SAO_START_SUFFIX`, `SAO_TEXT` OS LPI properties
-   */
-  sao?: string;
-  /**
-   * @title Secondary Addressable Object (SAO) end range
-   * @description Combined `SAO_END_NUMBER`, `SAO_END_SUFFIX` OS LPI properties
-   */
-  saoEnd?: string;
-  street: string;
-  town: string;
-  postcode: string;
-  organisation?: string;
-  singleLine: string;
-  source: 'Ordnance Survey';
-}
 
 export type PPProperty = PropertyBase & {
   materials?: Materials;

--- a/types/schemas/prototypeApplication/data/Proposal.ts
+++ b/types/schemas/prototypeApplication/data/Proposal.ts
@@ -1,3 +1,5 @@
+import {GeoBoundary} from '../../../shared/Boundaries';
+import {Materials} from '../../../shared/Materials';
 import {Area, Date, Integer} from '../../../shared/utils';
 import {PrimaryApplicationType} from '../enums/ApplicationType';
 import {BuildingRegulation} from '../enums/BuildingRegulation';
@@ -8,7 +10,7 @@ import {ProjectType} from '../enums/ProjectType';
 import {ProtectedSpaceDesignation} from '../enums/ProtectedSpaceDesignation';
 import {GLAResidentialUnitType} from '../enums/ResidentialUnitType';
 import {GLATenureType} from '../enums/TenureType';
-import {GeoBoundaryPrototype, Materials, ResidentialUnits} from './shared';
+import {ResidentialUnits} from './shared';
 
 /**
  * @description Information about the proposed works and any changes to the property
@@ -22,7 +24,7 @@ export interface EnglandProposal {
   /**
    * @description Location plan boundary proposed by the user, commonly referred to as the red line boundary
    */
-  boundary?: GeoBoundaryPrototype;
+  boundary?: GeoBoundary;
   /**
    * @description Proposed materials, if applicable to projectType
    */

--- a/types/schemas/prototypeApplication/data/shared.ts
+++ b/types/schemas/prototypeApplication/data/shared.ts
@@ -1,24 +1,6 @@
-import {GeoJSON} from 'geojson';
+import {URL} from '../../../shared/utils';
 import {UKResidentialUnitType} from '../enums/ResidentialUnitType';
 import {UKTenureType} from '../enums/TenureType';
-import {Area, URL} from '../../../shared/utils';
-
-export type Materials = {
-  boundary?: string;
-  door?: string;
-  lighting?: string;
-  roof?: string;
-  surface?: string;
-  wall?: string;
-  window?: string;
-  other?: string;
-};
-
-// TODO - Rename when prototype application replaces application
-export type GeoBoundaryPrototype = {
-  site: GeoJSON;
-  area: Area;
-};
 
 export type Entity = {
   name: string;

--- a/types/shared/Addresses.ts
+++ b/types/shared/Addresses.ts
@@ -48,7 +48,7 @@ export interface OSAddress extends SiteAddress {
    */
   usrn: string;
   /**
-   * @title Primary Addressable Object start range and/or building description
+   * @title Primary Addressable Object (PAO) start range and/or building description
    * @description Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties
    */
   pao: string;
@@ -73,4 +73,30 @@ export interface OSAddress extends SiteAddress {
   organisation?: string;
   singleLine: string;
   source: 'Ordnance Survey';
+}
+
+/**
+ * @description Address information for a person associated with this application not at the property address
+ */
+export interface Address {
+  line1: string;
+  line2?: string;
+  town: string;
+  county?: string;
+  postcode: string;
+  country?: string;
+}
+
+/**
+ * @title #UserAddress
+ * @description Address information for the applicant
+ */
+export type UserAddress = {sameAsSiteAddress: true} | UserAddressNotSameSite;
+
+/**
+ * @title #UserAddressNotSameSite
+ * @description Address information for an applicant with contact information that differs from the property address
+ */
+export interface UserAddressNotSameSite extends Address {
+  sameAsSiteAddress: false;
 }

--- a/types/shared/Addresses.ts
+++ b/types/shared/Addresses.ts
@@ -1,0 +1,76 @@
+/**
+ * @description Address information available for any site, whether existing or proposed
+ */
+export interface SiteAddress {
+  /**
+   * @description Single line address description
+   */
+  title: string;
+  /**
+   * @description Easting coordinate in British National Grid (OSGB36)
+   */
+  x: number;
+  /**
+   * @description Northing coordinate in British National Grid (OSGB36)
+   */
+  y: number;
+  /**
+   * @description Latitude coordinate in EPSG:4326 (WGS84)
+   */
+  latitude: number;
+  /**
+   * @description Longitude coordinate in EPSG:4326 (WGS84)
+   */
+  longitude: number;
+}
+
+/**
+ * @title #ProposedAddress
+ * @description Address information for sites without a known Unique Property Reference Number (UPRN)
+ */
+export interface ProposedAddress extends SiteAddress {
+  source: 'Proposed by applicant';
+}
+
+/**
+ * @title #OSAddress
+ * @description Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium LPI source
+ */
+export interface OSAddress extends SiteAddress {
+  /**
+   * @title Unique Property Reference Number
+   * @maxLength 12
+   */
+  uprn: string;
+  /**
+   * @title Unique Street Reference Number
+   * @maxLength 8
+   */
+  usrn: string;
+  /**
+   * @title Primary Addressable Object start range and/or building description
+   * @description Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties
+   */
+  pao: string;
+  /**
+   * @title Primary Addressable Object (PAO) end range
+   * @description Combined `PAO_END_NUMBER`, `PAO_END_SUFFIX` OS LPI properties
+   */
+  paoEnd?: string;
+  /**
+   * @title Secondary Addressable Object (SAO) start range and/or building description
+   * @description Combined `SAO_START_NUMBER`, `SAO_START_SUFFIX`, `SAO_TEXT` OS LPI properties
+   */
+  sao?: string;
+  /**
+   * @title Secondary Addressable Object (SAO) end range
+   * @description Combined `SAO_END_NUMBER`, `SAO_END_SUFFIX` OS LPI properties
+   */
+  saoEnd?: string;
+  street: string;
+  town: string;
+  postcode: string;
+  organisation?: string;
+  singleLine: string;
+  source: 'Ordnance Survey';
+}

--- a/types/shared/Boundaries.ts
+++ b/types/shared/Boundaries.ts
@@ -1,0 +1,7 @@
+import {GeoJSON} from 'geojson';
+import {Area} from './utils';
+
+export type GeoBoundary = {
+  site: GeoJSON;
+  area: Area;
+};

--- a/types/shared/Constraints.ts
+++ b/types/shared/Constraints.ts
@@ -1,0 +1,44 @@
+import {URL} from './utils';
+
+type PlanningDataSource = {
+  text: 'Planning Data';
+  url: URL;
+};
+
+type OSRoadsSource = {
+  text: 'Ordnance Survey MasterMap Highways';
+};
+
+export type Entity = {
+  name: string;
+  description?: string;
+  source: PlanningDataSource | OSRoadsSource;
+};
+
+type BasePlanningConstraint = {
+  value: string;
+  description: string;
+};
+
+/**
+ * @description A planning constraint that does not intersect with the proposed site, per the DE-9IM spatial relationship definition of intersects
+ */
+type NonIntersectingPlanningConstraint = {
+  intersects: false;
+} & BasePlanningConstraint;
+
+/**
+ * @description A planning constraint that does intersect with the proposed site, per the DE-9IM spatial relationship definition of intersects
+ */
+type IntersectingPlanningConstraint = {
+  intersects: true;
+  entities: Entity[];
+} & BasePlanningConstraint;
+
+/**
+ * @title #PlanningConstraint
+ * @description Planning constraints that intersect with the proposed site
+ */
+export type PlanningConstraint =
+  | NonIntersectingPlanningConstraint
+  | IntersectingPlanningConstraint;

--- a/types/shared/Contacts.ts
+++ b/types/shared/Contacts.ts
@@ -1,0 +1,20 @@
+import {Email} from './utils';
+
+/**
+ * @title #ContactDetails
+ * @description Contact details for a person associated with this application
+ */
+export type ContactDetails = {
+  name: {
+    title?: string;
+    first: string;
+    last: string;
+  };
+  email: Email;
+  phone: {
+    primary: string;
+  };
+  company?: {
+    name: string;
+  };
+};

--- a/types/shared/Declarations.ts
+++ b/types/shared/Declarations.ts
@@ -1,0 +1,16 @@
+/**
+ * @title #Declaration
+ * @description Declarations about the accuracy of this application and any personal connections to the receiving authority
+ */
+export interface Declaration {
+  accurate: boolean;
+  connection: {
+    value:
+      | 'employee'
+      | 'relation.employee'
+      | 'electedMember'
+      | 'relation.electedMember'
+      | 'none';
+    description?: string;
+  };
+}

--- a/types/shared/Fees.ts
+++ b/types/shared/Fees.ts
@@ -1,0 +1,106 @@
+/**
+ * @title #FeeNotApplicable
+ * @description An indicator that an application fee does not apply to this application type or journey
+ */
+export interface FeeNotApplicable {
+  notApplicable: true;
+}
+
+/**
+ * @title #Fee
+ * @description The costs associated with this application
+ */
+export interface Fee {
+  /**
+   * @description Total calculated fee in GBP
+   */
+  calculated: number;
+  /**
+   * @description Total payable fee after any exemptions or reductions in GBP
+   */
+  payable: number;
+  /**
+   * @description Breakdown of calculated fee in GBP by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2
+   */
+  category?: {
+    /**
+     * @description Category 1 - New homes
+     */
+    one?: number;
+    /**
+     * @description Category 2 - Other new buildings
+     */
+    two?: number;
+    /**
+     * @description Category 3 - Agricultural buildings
+     */
+    three?: number;
+    /**
+     * @description Category 4 - Glasshouses on agricultural land
+     */
+    four?: number;
+    /**
+     * @description Category 5 - Plant equipment or machinery
+     */
+    five?: number;
+    /**
+     * @description Category 6 and 7 - Home or curtilage of home
+     */
+    sixAndSeven?: number;
+    /**
+     * @description Category 8 - Car parks or access roads
+     */
+    eight?: number;
+    /**
+     * @description Category 9 - Exploratory drilling
+     */
+    nine?: number;
+    /**
+     * @description Category 10 - Winning and working of oil or natural gas
+     */
+    ten?: number;
+    eleven?: {
+      /**
+       * @description Category 11(1) - Mining operations
+       */
+      one?: number;
+      /**
+       * @description Category 11(2) - Other operations
+       */
+      two?: number;
+    };
+    twelve?: {
+      /**
+       * @description Category 12(1) - Change of use from single home to homes
+       */
+      one?: number;
+      /**
+       * @description Category 12(2) - Change of use to home
+       */
+      two?: number;
+    };
+    /**
+     * @description Category 13 - Waste disposal
+     */
+    thirteen?: number;
+    /**
+     * @description Category 14 - Other change of use
+     */
+    fourteen?: number;
+  };
+  exemption: {
+    disability: boolean; // @todo add application.fee.exemption.disability.reason
+    resubmission: boolean; // @todo add application.resubmission.original.applicationReference & application.resubmission.originalReference.appeal
+  };
+  reduction: {
+    alternative: boolean;
+    parishCouncil: boolean;
+    sports: boolean;
+  };
+  reference?: {
+    /**
+     * @description GOV.UK Pay payment reference number
+     */
+    govPay: string; // @todo require when payable > 0
+  };
+}

--- a/types/shared/Materials.ts
+++ b/types/shared/Materials.ts
@@ -1,0 +1,10 @@
+export type Materials = {
+  boundary?: string;
+  door?: string;
+  lighting?: string;
+  roof?: string;
+  surface?: string;
+  wall?: string;
+  window?: string;
+  other?: string;
+};

--- a/types/shared/Ownership.ts
+++ b/types/shared/Ownership.ts
@@ -1,0 +1,67 @@
+import {Address} from './Addresses';
+import {Date} from './utils';
+
+export type OwnersInterest = 'owner' | 'lessee' | 'occupier' | 'other';
+
+/**
+ * @title #Ownership
+ * @description Information about the ownership certificate and property owners, if different than the applicant
+ */
+export interface Ownership {
+  interest?: OwnersInterest | 'owner.sole' | 'owner.co';
+  certificate?: 'a' | 'b' | 'c' | 'd';
+  /**
+   * @description Does the land have any agricultural tenants?
+   */
+  agriculturalTenants?: boolean;
+  /**
+   * @description Has requisite notice been given to all the known owners and agricultural tenants?
+   */
+  noticeGiven?: boolean;
+  /**
+   * @description Has a notice of the application been published in a newspaper circulating in the area where the land is situated?
+   */
+  noticePublished?: {
+    status: boolean;
+    date?: Date;
+    newspaperName?: string;
+  };
+  /**
+   * @description Do you know the names and addresses of all owners and agricultural tenants?
+   */
+  ownersKnown?: 'all' | 'some' | 'none';
+  owners?: Owners[];
+  /**
+   * @description Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice
+   */
+  declaration?: {
+    accurate: true;
+  };
+}
+
+/**
+ * @title #Owners
+ * @description Names and addresses of all known owners and agricultural tenants who are not the applicant, including confirmation or date of notice, or reason requisite notice has not been given if applicable
+ */
+export type Owners = OwnersNoticeGiven | OwnersNoNoticeGiven | OwnersNoticeDate;
+
+export interface BaseOwners {
+  name: string;
+  address: Address | string;
+  interest?: OwnersInterest;
+}
+
+// LDC requires `noticeGiven`, and `noNoticeReason` if false
+export interface OwnersNoticeGiven extends BaseOwners {
+  noticeGiven: true;
+}
+
+export interface OwnersNoNoticeGiven extends BaseOwners {
+  noticeGiven: false;
+  noNoticeReason: string;
+}
+
+// PP & LBC require `noticeDate`
+export interface OwnersNoticeDate extends BaseOwners {
+  noticeDate: Date;
+}

--- a/types/shared/Regions.ts
+++ b/types/shared/Regions.ts
@@ -1,0 +1,14 @@
+/**
+ * @title #Region
+ * @description The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area
+ */
+export type Region =
+  | 'North East'
+  | 'North West'
+  | 'Yorkshire and The Humber'
+  | 'East Midlands'
+  | 'West Midlands'
+  | 'East of England'
+  | 'London'
+  | 'South East'
+  | 'South West';


### PR DESCRIPTION
Lots of refactors to the `/shared` types folder ! 

This one is big enough as-is, haven't touched the following yet but will in follow-up PRs: 
- Shared `enums`
- Resolve outstanding feedback & combine `application` & `prototypeApplication` into single `@next` `application`
- Review use of `@id` versus `@title` annotations (especially with docs viewer output)