### PR TITLE
Add data.application.type for PreApplication schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
+build
 node_modules

--- a/examples/preApplication/data/preApp.ts
+++ b/examples/preApplication/data/preApp.ts
@@ -202,6 +202,10 @@ export const preApplication: PreApplication = {
       },
     },
     application: {
+      type: {
+        value: 'preApp',
+        description: 'Pre-application advice',
+      },
       fee: {
         payable: 450,
         reference: {

--- a/examples/preApplication/preApp.json
+++ b/examples/preApplication/preApp.json
@@ -221,6 +221,10 @@
       }
     },
     "application": {
+      "type": {
+        "value": "preApp",
+        "description": "Pre-application advice"
+      },
       "fee": {
         "payable": 450,
         "reference": {

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -4,7 +4,6 @@
   "additionalProperties": false,
   "definitions": {
     "Address": {
-      "$id": "#Address",
       "additionalProperties": false,
       "description": "Address information for a person associated with this application not at the property address",
       "properties": {
@@ -96,10 +95,10 @@
             }
           },
           "required": [
-            "name",
+            "address",
             "email",
-            "phone",
-            "address"
+            "name",
+            "phone"
           ],
           "type": "object"
         },
@@ -180,40 +179,6 @@
       ],
       "type": "object"
     },
-    "AnyProviderMetadata": {
-      "$id": "#AnyProviderMetadata",
-      "additionalProperties": false,
-      "description": "Base metadata associated with applications submitted via any provider",
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/UUID",
-          "description": "Unique identifier for this application"
-        },
-        "organisation": {
-          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
-          "maxLength": 4,
-          "type": "string"
-        },
-        "schema": {
-          "$ref": "#/definitions/URL"
-        },
-        "source": {
-          "const": "Any",
-          "type": "string"
-        },
-        "submittedAt": {
-          "$ref": "#/definitions/DateTime"
-        }
-      },
-      "required": [
-        "id",
-        "organisation",
-        "schema",
-        "source",
-        "submittedAt"
-      ],
-      "type": "object"
-    },
     "Applicant": {
       "$id": "#Applicant",
       "anyOf": [
@@ -225,43 +190,6 @@
         }
       ],
       "description": "The user who completed the application either for themself or on behalf of someone else"
-    },
-    "ApplicationDeclaration": {
-      "$id": "#ApplicationDeclaration",
-      "additionalProperties": false,
-      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
-      "properties": {
-        "accurate": {
-          "type": "boolean"
-        },
-        "connection": {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "type": "string"
-            },
-            "value": {
-              "enum": [
-                "employee",
-                "relation.employee",
-                "electedMember",
-                "relation.electedMember",
-                "none"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "value"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "accurate",
-        "connection"
-      ],
-      "type": "object"
     },
     "Area": {
       "$id": "#Area",
@@ -375,14 +303,158 @@
         }
       },
       "required": [
-        "type",
-        "name",
-        "email",
-        "phone",
         "address",
-        "siteContact"
+        "email",
+        "name",
+        "phone",
+        "siteContact",
+        "type"
       ],
       "type": "object"
+    },
+    "BasePlanningDesignation": {
+      "anyOf": [
+        {
+          "const": "article4",
+          "description": "Article 4 Direction area",
+          "type": "string"
+        },
+        {
+          "const": "article4.caz",
+          "description": "Central Activities Zone (CAZ)",
+          "type": "string"
+        },
+        {
+          "const": "brownfieldSite",
+          "description": "Brownfield site",
+          "type": "string"
+        },
+        {
+          "const": "designated",
+          "description": "Designated land",
+          "type": "string"
+        },
+        {
+          "const": "designated.AONB",
+          "description": "Area of Outstanding Natural Beauty (AONB)",
+          "type": "string"
+        },
+        {
+          "const": "designated.conservationArea",
+          "description": "Conservation Area",
+          "type": "string"
+        },
+        {
+          "const": "designated.nationalPark",
+          "description": "National Park",
+          "type": "string"
+        },
+        {
+          "const": "designated.nationalPark.broads",
+          "description": "National Park - Broads",
+          "type": "string"
+        },
+        {
+          "const": "designated.WHS",
+          "description": "UNESCO World Heritage Site or buffer zone",
+          "type": "string"
+        },
+        {
+          "const": "flood",
+          "description": "Flood Risk Zone",
+          "type": "string"
+        },
+        {
+          "const": "flood.zone.1",
+          "description": "Flood Risk Zone 1 - Low risk",
+          "type": "string"
+        },
+        {
+          "const": "flood.zone.2",
+          "description": "Flood Risk Zone 2 - Medium risk",
+          "type": "string"
+        },
+        {
+          "const": "flood.zone.3",
+          "description": "Flood Risk Zone 3 - High risk",
+          "type": "string"
+        },
+        {
+          "const": "greenBelt",
+          "description": "Green Belt",
+          "type": "string"
+        },
+        {
+          "const": "listed",
+          "description": "Listed Building",
+          "type": "string"
+        },
+        {
+          "const": "listed.grade.I",
+          "description": "Listed Building - Grade I",
+          "type": "string"
+        },
+        {
+          "const": "listed.grade.II",
+          "description": "Listed Building - Grade II",
+          "type": "string"
+        },
+        {
+          "const": "listed.grade.II*",
+          "description": "Listed Building - Grade II*",
+          "type": "string"
+        },
+        {
+          "const": "locallyListed",
+          "description": "Locally Listed Building",
+          "type": "string"
+        },
+        {
+          "const": "monument",
+          "description": "Site of a Scheduled Monument",
+          "type": "string"
+        },
+        {
+          "const": "nature.ASNW",
+          "description": "Ancient Semi-Natural Woodland (ASNW)",
+          "type": "string"
+        },
+        {
+          "const": "nature.ramsarSite",
+          "description": "Ramsar site",
+          "type": "string"
+        },
+        {
+          "const": "nature.SAC",
+          "description": "Special Area of Conservation (SAC)",
+          "type": "string"
+        },
+        {
+          "const": "nature.SPA",
+          "description": "Special Protection Area (SPA)",
+          "type": "string"
+        },
+        {
+          "const": "nature.SSSI",
+          "description": "Site of Special Scientific Interest (SSSI)",
+          "type": "string"
+        },
+        {
+          "const": "registeredPark",
+          "description": "Historic Park or Garden",
+          "type": "string"
+        },
+        {
+          "const": "road.classified",
+          "description": "Classified Road",
+          "type": "string"
+        },
+        {
+          "const": "tpo",
+          "description": "Tree Preservation Order (TPO) or zone",
+          "type": "string"
+        }
+      ]
     },
     "CalculateMetadata": {
       "$id": "#CalculateMetadata",
@@ -413,6 +485,65 @@
       },
       "type": "object"
     },
+    "ContactDetails": {
+      "additionalProperties": false,
+      "description": "Contact details for a person associated with this application",
+      "properties": {
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "email",
+        "phone"
+      ],
+      "title": "#ContactDetails",
+      "type": "object"
+    },
     "Date": {
       "format": "date",
       "type": "string"
@@ -422,6 +553,43 @@
       "format": "date-time",
       "pattern": "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$",
       "type": "string"
+    },
+    "Declaration": {
+      "additionalProperties": false,
+      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
+      "properties": {
+        "accurate": {
+          "type": "boolean"
+        },
+        "connection": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "value": {
+              "enum": [
+                "employee",
+                "relation.employee",
+                "electedMember",
+                "relation.electedMember",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "accurate",
+        "connection"
+      ],
+      "title": "#Declaration",
+      "type": "object"
     },
     "Email": {
       "format": "email",
@@ -720,1811 +888,29 @@
       ],
       "type": "object"
     },
-    "FileType": {
-      "$id": "#FileType",
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Details of impact on access, roads, and rights of way",
-              "type": "string"
-            },
-            "value": {
-              "const": "accessRoadsRightsOfWayDetails",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Affordable housing statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "affordableHousingStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Arboriculturist report",
-              "type": "string"
-            },
-            "value": {
-              "const": "arboriculturistReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bank statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "bankStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Basement impact statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "basementImpactStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bio-aerosol assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "bioaerosolAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Birdstrike risk management plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "birdstrikeRiskManagementPlan",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Borehole or trial pit analysis",
-              "type": "string"
-            },
-            "value": {
-              "const": "boreholeOrTrialPitAnalysis",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Building control certificate",
-              "type": "string"
-            },
-            "value": {
-              "const": "buildingControlCertificate",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Structural or building condition survey",
-              "type": "string"
-            },
-            "value": {
-              "const": "conditionSurvey",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Construction invoice",
-              "type": "string"
-            },
-            "value": {
-              "const": "constructionInvoice",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Contamination report",
-              "type": "string"
-            },
-            "value": {
-              "const": "contaminationReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Council tax bill",
-              "type": "string"
-            },
-            "value": {
-              "const": "councilTaxBill",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Crime prevention strategy",
-              "type": "string"
-            },
-            "value": {
-              "const": "crimePreventionStrategy",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Design and Access Statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "designAndAccessStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Evidence for application fee exemption - disability",
-              "type": "string"
-            },
-            "value": {
-              "const": "disabilityExemptionEvidence",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Ecology report",
-              "type": "string"
-            },
-            "value": {
-              "const": "ecologyReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Elevations - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "elevations.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Elevations - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "elevations.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Scheme for mitigation and monitoring of emissions (dust, odour and vibrations)",
-              "type": "string"
-            },
-            "value": {
-              "const": "emissionsMitigationAndMonitoringScheme",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Energy statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "energyStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Environmental Impact Assessment (EIA)",
-              "type": "string"
-            },
-            "value": {
-              "const": "environmentalImpactAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "External materials details",
-              "type": "string"
-            },
-            "value": {
-              "const": "externalMaterialsDetails",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fire safety report",
-              "type": "string"
-            },
-            "value": {
-              "const": "fireSafetyReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Flood risk assessment (FRA)",
-              "type": "string"
-            },
-            "value": {
-              "const": "floodRiskAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Floor plan - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "floorPlan.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Floor plan - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "floorPlan.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Foul drainage assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "foulDrainageAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Geodiversity assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "geodiversityAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Plans showing the stretches of hedgerows to be removed",
-              "type": "string"
-            },
-            "value": {
-              "const": "hedgerowsInformation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Evidence of the date of planting of the removed hedgerows",
-              "type": "string"
-            },
-            "value": {
-              "const": "hedgerowsInformation.plantingDate",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Heritage Statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "heritageStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hydrological and hydrogeological assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "hydrologicalAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hydrology report",
-              "type": "string"
-            },
-            "value": {
-              "const": "hydrologyReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Internal elevations",
-              "type": "string"
-            },
-            "value": {
-              "const": "internalElevations",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Internal sections",
-              "type": "string"
-            },
-            "value": {
-              "const": "internalSections",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Joiner's report",
-              "type": "string"
-            },
-            "value": {
-              "const": "joinersReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Joinery section report",
-              "type": "string"
-            },
-            "value": {
-              "const": "joinerySections",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Land contamination assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "landContaminationAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Landscape and visual impact assessment (LVIA)",
-              "type": "string"
-            },
-            "value": {
-              "const": "landscapeAndVisualImpactAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Landscape strategy or landscape plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "landscapeStrategy",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Lighting assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "lightingAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Details of litter, vermin and bird control",
-              "type": "string"
-            },
-            "value": {
-              "const": "litterVerminAndBirdControlDetails",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Location plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "locationPlan",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Method statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "methodStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Minerals and waste assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "mineralsAndWasteAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Information the authority considers necessary for the application",
-              "type": "string"
-            },
-            "value": {
-              "const": "necessaryInformation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "New dwellings schedule",
-              "type": "string"
-            },
-            "value": {
-              "const": "newDwellingsSchedule",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Noise assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "noiseAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Open space assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "openSpaceAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other - document",
-              "type": "string"
-            },
-            "value": {
-              "const": "otherDocument",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other - drawing",
-              "type": "string"
-            },
-            "value": {
-              "const": "otherDrawing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other - evidence or correspondence",
-              "type": "string"
-            },
-            "value": {
-              "const": "otherEvidence",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Parking plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "parkingPlan",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Photographs - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "photographs.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Photographs - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "photographs.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Planning statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "planningStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Recyclable waste storage details",
-              "type": "string"
-            },
-            "value": {
-              "const": "recycleWasteStorageDetails",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Information the applicant considers relevant to the application",
-              "type": "string"
-            },
-            "value": {
-              "const": "relevantInformation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Residential units details",
-              "type": "string"
-            },
-            "value": {
-              "const": "residentialUnitsDetails",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Roof plan - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "roofPlan.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Roof plan - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "roofPlan.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sections - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "sections.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sections - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "sections.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Site plan - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "sitePlan.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Site plan - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "sitePlan.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sketch plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "sketchPlan",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Statement of community involvement",
-              "type": "string"
-            },
-            "value": {
-              "const": "statementOfCommunityInvolvement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Statutory declaration",
-              "type": "string"
-            },
-            "value": {
-              "const": "statutoryDeclaration",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Details of storage treatment or disposal of waste",
-              "type": "string"
-            },
-            "value": {
-              "const": "storageTreatmentAndWasteDisposalDetails",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Street scene drawing",
-              "type": "string"
-            },
-            "value": {
-              "const": "streetScene",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Subsidence report",
-              "type": "string"
-            },
-            "value": {
-              "const": "subsidenceReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sunlight and daylight report",
-              "type": "string"
-            },
-            "value": {
-              "const": "sunlightAndDaylightReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sustainability statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "sustainabilityStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Technical evidence",
-              "type": "string"
-            },
-            "value": {
-              "const": "technicalEvidence",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Technical specification",
-              "type": "string"
-            },
-            "value": {
-              "const": "technicalSpecification",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Tenancy agreement",
-              "type": "string"
-            },
-            "value": {
-              "const": "tenancyAgreement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Tenancy invoice",
-              "type": "string"
-            },
-            "value": {
-              "const": "tenancyInvoice",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Town centre uses - Impact assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "townCentreImpactAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Town centre uses - Sequential assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "townCentreSequentialAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Transport assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "transportAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Travel plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "travelPlan",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Location of trees and hedges",
-              "type": "string"
-            },
-            "value": {
-              "const": "treeAndHedgeLocation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Removed or pruned trees and hedges",
-              "type": "string"
-            },
-            "value": {
-              "const": "treeAndHedgeRemovedOrPruned",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Tree canopy calculator",
-              "type": "string"
-            },
-            "value": {
-              "const": "treeCanopyCalculator",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Tree condition report",
-              "type": "string"
-            },
-            "value": {
-              "const": "treeConditionReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Tree plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "treePlan",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Trees report",
-              "type": "string"
-            },
-            "value": {
-              "const": "treesReport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Unit plan - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "unitPlan.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Unit plan - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "unitPlan.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Use plan - existing",
-              "type": "string"
-            },
-            "value": {
-              "const": "usePlan.existing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Use plan - proposed",
-              "type": "string"
-            },
-            "value": {
-              "const": "usePlan.proposed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Utility bill",
-              "type": "string"
-            },
-            "value": {
-              "const": "utilityBill",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Utilities statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "utilitiesStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Ventilation or extraction statement",
-              "type": "string"
-            },
-            "value": {
-              "const": "ventilationStatement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Viability Appraisal",
-              "type": "string"
-            },
-            "value": {
-              "const": "viabilityAppraisal",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Visualisations",
-              "type": "string"
-            },
-            "value": {
-              "const": "visualisations",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Waste and recycling strategy",
-              "type": "string"
-            },
-            "value": {
-              "const": "wasteAndRecyclingStrategy",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Waste storage details",
-              "type": "string"
-            },
-            "value": {
-              "const": "wasteStorageDetails",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water environment assessment",
-              "type": "string"
-            },
-            "value": {
-              "const": "waterEnvironmentAssessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
+    "File": {
+      "$id": "#File",
+      "additionalProperties": false,
+      "description": "File uploaded and labeled by the user to support the application",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
         }
+      },
+      "required": [
+        "name",
+        "type"
       ],
-      "description": "Types of planning documents and drawings"
+      "type": "object"
     },
     "GeoBoundary": {
       "additionalProperties": false,
@@ -2654,52 +1040,7 @@
             "$ref": "#/definitions/Address"
           },
           "contact": {
-            "additionalProperties": false,
-            "properties": {
-              "company": {
-                "additionalProperties": false,
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ],
-                "type": "object"
-              },
-              "email": {
-                "type": "string"
-              },
-              "name": {
-                "additionalProperties": false,
-                "properties": {
-                  "first": {
-                    "type": "string"
-                  },
-                  "last": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "first",
-                  "last"
-                ],
-                "type": "object"
-              },
-              "phone": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "email",
-              "phone"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/ContactDetails"
           },
           "when": {
             "enum": [
@@ -2718,18 +1059,6 @@
         "type": "object"
       },
       "type": "array"
-    },
-    "Metadata": {
-      "$id": "#DigitalPlanningMetadata",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/AnyProviderMetadata"
-        },
-        {
-          "$ref": "#/definitions/PlanXMetadata"
-        }
-      ],
-      "description": "Details of the digital planning service which sent this application"
     },
     "MultiLineString": {
       "additionalProperties": false,
@@ -2819,9 +1148,8 @@
       "type": "object"
     },
     "OSAddress": {
-      "$id": "#OSAddress",
       "additionalProperties": false,
-      "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium",
+      "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium LPI source",
       "properties": {
         "latitude": {
           "description": "Latitude coordinate in EPSG:4326 (WGS84)",
@@ -2836,7 +1164,7 @@
         },
         "pao": {
           "description": "Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties",
-          "title": "Primary Addressable Object start range and/or building description",
+          "title": "Primary Addressable Object (PAO) start range and/or building description",
           "type": "string"
         },
         "paoEnd": {
@@ -2868,6 +1196,7 @@
           "type": "string"
         },
         "title": {
+          "description": "Single line address description",
           "type": "string"
         },
         "town": {
@@ -2907,10 +1236,10 @@
         "x",
         "y"
       ],
+      "title": "#OSAddress",
       "type": "object"
     },
     "Owners": {
-      "$id": "#Owners",
       "anyOf": [
         {
           "$ref": "#/definitions/OwnersNoticeGiven"
@@ -2922,7 +1251,17 @@
           "$ref": "#/definitions/OwnersNoticeDate"
         }
       ],
-      "description": "Names and addresses of all known owners and agricultural tenants, including confirmation or date of notice, or reason requisite notice has not been given if applicable"
+      "description": "Names and addresses of all known owners and agricultural tenants who are not the applicant, including confirmation or date of notice, or reason requisite notice has not been given if applicable",
+      "title": "#Owners"
+    },
+    "OwnersInterest": {
+      "enum": [
+        "owner",
+        "lessee",
+        "occupier",
+        "other"
+      ],
+      "type": "string"
     },
     "OwnersNoNoticeGiven": {
       "additionalProperties": false,
@@ -2938,13 +1277,7 @@
           ]
         },
         "interest": {
-          "enum": [
-            "owner",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -2979,13 +1312,7 @@
           ]
         },
         "interest": {
-          "enum": [
-            "owner",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -3015,13 +1342,7 @@
           ]
         },
         "interest": {
-          "enum": [
-            "owner",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "$ref": "#/definitions/OwnersInterest"
         },
         "name": {
           "type": "string"
@@ -3039,7 +1360,6 @@
       "type": "object"
     },
     "Ownership": {
-      "$id": "#Ownership",
       "additionalProperties": false,
       "description": "Information about the ownership certificate and property owners, if different than the applicant",
       "properties": {
@@ -3071,15 +1391,19 @@
           "type": "object"
         },
         "interest": {
-          "enum": [
-            "owner",
-            "owner.sole",
-            "owner.co",
-            "lessee",
-            "occupier",
-            "other"
-          ],
-          "type": "string"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OwnersInterest"
+            },
+            {
+              "const": "owner.sole",
+              "type": "string"
+            },
+            {
+              "const": "owner.co",
+              "type": "string"
+            }
+          ]
         },
         "noticeGiven": {
           "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
@@ -3120,72 +1444,7 @@
           "type": "string"
         }
       },
-      "type": "object"
-    },
-    "PlanXMetadata": {
-      "$id": "#PlanXMetadata",
-      "additionalProperties": false,
-      "description": "Additional metadata associated with applications submitted via PlanX",
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/UUID",
-          "description": "Unique identifier for this application"
-        },
-        "organisation": {
-          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
-          "maxLength": 4,
-          "type": "string"
-        },
-        "schema": {
-          "$ref": "#/definitions/URL"
-        },
-        "service": {
-          "additionalProperties": false,
-          "properties": {
-            "fee": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FeeExplanation"
-                },
-                {
-                  "$ref": "#/definitions/FeeExplanationNotApplicable"
-                }
-              ]
-            },
-            "files": {
-              "$ref": "#/definitions/RequestedFiles"
-            },
-            "flowId": {
-              "$ref": "#/definitions/UUID"
-            },
-            "url": {
-              "$ref": "#/definitions/URL"
-            }
-          },
-          "required": [
-            "flowId",
-            "url",
-            "files",
-            "fee"
-          ],
-          "type": "object"
-        },
-        "source": {
-          "const": "PlanX",
-          "type": "string"
-        },
-        "submittedAt": {
-          "$ref": "#/definitions/DateTime"
-        }
-      },
-      "required": [
-        "id",
-        "organisation",
-        "schema",
-        "service",
-        "source",
-        "submittedAt"
-      ],
+      "title": "#Ownership",
       "type": "object"
     },
     "PlanningDesignation": {
@@ -4725,14 +2984,27 @@
       "description": "Information about this planning pre-application",
       "properties": {
         "declaration": {
-          "$ref": "#/definitions/ApplicationDeclaration"
+          "$ref": "#/definitions/Declaration"
         },
         "fee": {
           "additionalProperties": false,
           "properties": {
             "payable": {
-              "description": "Total payable fee in GBP",
+              "description": "Total payable fee after any exemptions or reductions in GBP",
               "type": "number"
+            },
+            "reference": {
+              "additionalProperties": false,
+              "properties": {
+                "govPay": {
+                  "description": "GOV.UK Pay payment reference number",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "govPay"
+              ],
+              "type": "object"
             }
           },
           "required": [
@@ -4781,14 +3053,96 @@
             "sensitive"
           ],
           "type": "object"
+        },
+        "type": {
+          "$ref": "#/definitions/PreApplicationType"
         }
       },
       "required": [
+        "type",
         "fee",
         "declaration",
         "information"
       ],
       "type": "object"
+    },
+    "PreApplicationType": {
+      "$id": "#PreApplicationType",
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice - Householder",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp.householder",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice - Minor",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp.minor",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice - Major",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp.major",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Planning application types"
     },
     "Property": {
       "additionalProperties": false,
@@ -4838,7 +3192,7 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/UKRegion"
+          "$ref": "#/definitions/Region"
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
@@ -4856,8356 +3210,2324 @@
       "$id": "#PropertyType",
       "anyOf": [
         {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Commercial",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Agricultural",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.agriculture",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Farm / Non-Residential Associated Building",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.agriculture.farm",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fishery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.fish",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fish Farming",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.fish.farm",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fish Hatchery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.fish.hatchery",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fish Processing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.fish.processing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Oyster / Mussel Bed",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.fish.oysters",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Horticulture",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.horticulture",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Smallholding",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.horticulture.smallholding",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Vineyard",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.horticulture.vineyard",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Watercress Bed",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.horticulture.watercress",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Slaughter House / Abattoir",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.abattoir",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Ancillary Building",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.ancilliary",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Community Services",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Law Court",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.court",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Prison",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.prison",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "HM Detention Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.prison.detention",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "HM Prison Service",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.prison.service",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Secure Residential Accommodation",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.prison.secureResidential",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public / Village Hall / Other Community Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.hall",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Youth Recreational / Social Club",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.hall.club",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public Convenience",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.wc",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cemetery / Crematorium / Graveyard. In Current Use.",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.cemetary",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Columbarium",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.cemetary.columbarium",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Crematorium",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.cemetary.crematorium",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Chapel Of Rest",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.cemetary.chapelOfRest",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cemetery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.cemetary.cemetary",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Military Cemetery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.cemetary.military",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mortuary",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.cemetary.mortuary",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Church Hall / Religious Meeting Place / Hall",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.religious",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Community Service Centre / Office",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.services",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public Household Waste Recycling Centre (HWRC)",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.HWRC",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Recycling Site",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.recycling",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "CCTV",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.CCTV",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Job Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.community.employment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Education",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "College",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.college",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Further Education",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.college.further",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Higher Education",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.college.higher",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Children's Nursery / Crèche",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.nursery",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Preparatory / First / Primary / Infant / Junior / Middle School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.school",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "First School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.school.first",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Infant School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.school.infant",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Junior School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.school.junior",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Middle School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.school.middle",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Non State Primary / Preparatory School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.school.primary.private",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Primary School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.school.primary.state",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Secondary / High School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.secondarySchool",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Non State Secondary School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.secondarySchool.private",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Secondary School",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.secondarySchool.state",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "University",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.university",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Special Needs Establishment.",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.specialNeeds",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other Educational Establishment",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.education.other",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hotel / Motel / Boarding / Guest House",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.guest",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Boarding / Guest House / Bed And Breakfast / Youth Hostel",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.guest.hostel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Youth Hostel",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.guest.hostel.youth",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Holiday Let/Accomodation/Short-Term Let Other Than CH01",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.guest.shortLet",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hotel/Motel",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.guest.hotel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Industrial Applicable to manufacturing, engineering, maintenance, storage / wholesale distribution and extraction sites",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Factory/Manufacturing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Aircraft Works",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.aircraft",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Boat Building",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.boats",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Brick Works",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.bricks",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Brewery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.beer",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cider Manufacture",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.cider",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Chemical Works",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.chemicals",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cement Works",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.cement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Dairy Processing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.dairy",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Distillery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.distillery",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Flour Mill",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.flour",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Food Processing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.food",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Glassworks",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.glass",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Manufacturing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.other",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Oast House",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.hops",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Oil Refining",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.oil",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Pottery Manufacturing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.pottery",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Paper Mill",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.paper",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Printing Works",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.printing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sugar Refinery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.sugar",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Steel Works",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.steel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Timber Mill",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.timber",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Winery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.wine",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Shipyard",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.manufacturing.ships",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mineral / Ore Working / Quarry / Mine",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.extraction",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mineral Mining / Active",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.extraction.mining",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mineral Distribution / Storage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.extraction.distribution",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mineral Processing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.extraction.processing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Oil / Gas Extraction / Active",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.extraction.oilGas",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mineral Quarrying / Open Extraction / Active",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.extraction.quarrying",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Workshop / Light Industrial",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.light",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Servicing Garage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.light.garage",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Warehouse / Store / Storage Depot",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.light.storage",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Crop Handling / Storage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.light.storage.crops",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Postal Sorting / Distribution",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.light.storage.post",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Solid Fuel Storage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.light.storage.solidFuel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Timber Storage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.light.storage.timber",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Wholesale Distribution",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.distribution",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Solid Fuel Distribution",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.distribution.solidFueld",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Timber Distribution",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.distribution.timber",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Recycling Plant",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.recycling",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Incinerator / Waste Transfer Station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.incineration",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Maintenance Depot",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.industrial.maintenanceDepot",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Leisure - Applicable to recreational sites and enterprises",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Amusements",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.amusements",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Leisure Pier",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.amusements.pier",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Holiday / Campsite",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.holiday",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Camping",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.holiday.camping",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Caravanning",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.holiday.caravanning",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Holiday Accommodation",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.holiday.accommodation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Holiday Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.holiday.centre",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Youth Organisation Camp",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.holiday.youth",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Library",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.library",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Reading Room",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.library.readingRoom",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Museum / Gallery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Art Centre / Gallery",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.art",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Aviation Museum",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.aviation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Heritage Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.heritage",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Industrial Museum",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.industrial",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Military Museum",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.military",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Maritime Museum",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.maritime",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Science Museum",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.science",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Transport Museum",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.museum.transport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Indoor / Outdoor Leisure / Sporting Activity / Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Athletics Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.athletics",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bowls Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.bowls",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cricket Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.cricket",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Curling Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.curling",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Diving / Swimming Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.swimming",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Equestrian Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.equestrian",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Football Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.football",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fishing / Angling Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.fishing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Golf Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.golf",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Gliding Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.gliding",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Greyhound Racing Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.dogracing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hockey Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.hockey",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Horse Racing Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.horseracing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Historic Vessel / Aircraft / Vehicle",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.historicVehicles",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Activity / Leisure / Sports Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.centre",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Model Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.model",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Motor Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.motor",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Playing Field",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.playingField",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Racquet Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.racquet",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rugby Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.rugby",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Recreation Ground",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.recreationGround",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Shinty Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.shinty",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Skateboarding Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.skateboarding",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Civilian Firing Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.firing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Tenpin Bowling Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.tenpin",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public Tennis Court",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.tennis",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.water",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Winter Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.winter",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Wildlife Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.wildlife",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cycling Sports Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.sport.cycling",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bingo Hall / Cinema / Conference / Exhibition Centre / Theatre / Concert Hall",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.entertainment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cinema",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.entertainment.cinema",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Entertainment Complex",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.entertainment.mixed",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Conference / Exhibition Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.entertainment.exhibition",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Theatre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.entertainment.theatre",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Zoo / Theme Park",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.park.zoo",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Amusement Park",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.park.amusement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Aquatic Attraction",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.park.aquatic",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Model Village Site",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.park.model",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Wildlife / Zoological Park",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.park.wildlife",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Beach Hut (Recreational, Non-Residential Use Only)",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.beachHut",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Licensed Private Members' Club",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.club.private",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Recreational / Social Club",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.club.social",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Arena / Stadium",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.arena",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Stadium",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.arena.stadium",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Showground",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.leisure.arena.showground",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Medical",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Dentist",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.dentist",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "General Practice Surgery / Clinic",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.GP",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Health Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.healthCentre",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Health Care Services",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.healthServices",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hospital / Hospice",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.care",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Care home/Hospice",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.care.home",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hospital",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.care.hospital",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Medical / Testing / Research Laboratory",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.lab",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Professional Medical Service",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.professional",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Assessment / Development Services",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.medical.assessment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Animal Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cattery / Kennel",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.kennelsCattery",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Animal Services",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.services",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Animal Quarantining",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.services.quarantine",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Equestrian",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.equestrian",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Horse Racing / Breeding Stable",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.equestrian.racing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Commercial Stabling / Riding",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.equestrian.riding",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Vet / Animal Medical Treatment",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.vet",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Animal / Bird / Marine Sanctuary",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.sanctuary",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Animal Sanctuary",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.sanctuary.animals",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Marine Sanctuary",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.animals.sanctuary.marine",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Office",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.office",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Office / Work Studio",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.office.workspace",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Embassy /, High Commission / Consulate",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.office.workspace.embassy",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Film Studio",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.office.workspace.film",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Central Government Service",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.office.workspace.gov.national",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Local Government Service",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.office.workspace.gov.local",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Broadcasting (TV / Radio)",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.office.broadcasting",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Retail",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bank / Financial Service",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.financial",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Retail Service Agent",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.services",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Post Office",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.post",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Market (Indoor / Outdoor)",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.market",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fish Market",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.market.fish",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fruit / Vegetable Market",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.market.fruit",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Livestock Market",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.market.livestock",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Petrol Filling Station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.fuel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public House / Bar / Nightclub",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.drinking",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Restaurant / Cafeteria",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.restaurant",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Shop / Showroom",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.showroom",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Shop",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.shop",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Garden Centre",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.shop.gardenCentre",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other Licensed Premise / Vendor",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.licensedPremises",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fast Food Outlet / Takeaway (Hot / Cold)",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.takeaway",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Automated Teller Machine (ATM)",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.retail.atm",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Storage Land",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.storageLand",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "General Storage Land",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.storageLand.general",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Builders' Yard",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.storageLand.building",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Transport",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Airfield / Airstrip / Airport / Air Transport Infrastructure Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.air",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Airfield",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.air.airfield",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Air Transport Infrastructure Services",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.air.infrastructure",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Airport",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.air.airport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Air Passenger Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.air.passengerTerminal",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Helicopter Station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.air.helicopterStation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Heliport / Helipad",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.air.heliport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bus Shelter",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.bus",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Car / Coach / Commercial Vehicle / Taxi Parking / Park And Ride Site",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.parking",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public Park And Ride",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.parking.parkAndRide",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public Car Parking",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.parking.car",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public Coach Parking",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.parking.coach",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Public Commercial Vehicle Parking",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.parking.commercialVehicle",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Goods Freight Handling / Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.freight",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Air Freight Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.freight.air",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Container Freight",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.freight.container",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Road Freight Transport",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.freight.road",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rail Freight Transport",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.freight.rail",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Marina",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.marina",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mooring",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.mooring",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Railway Asset",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.railAsset",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Station / Interchange / Terminal / Halt",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.terminal",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bus station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.terminal.bus",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Train station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.terminal.train",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Vehicular Rail Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.terminal.vehicularRail",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Transport Track / Way",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.track",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cliff Railway",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.track.cliff",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Chair Lift / Cable Car / Ski Tow",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.track.cable",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Monorail",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.track.monorail",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Vehicle Storage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.storage",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Boat Storage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.storage.boat",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Bus / Coach Depot",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.storage.bus",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Transport Related Infrastructure",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.infrastructure",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Aqueduct",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.infrastructure.aqueduct",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Lock",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.infrastructure.lock",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Weir",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.infrastructure.weir",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Weighbridge / Load Gauge",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.infrastructure.weighing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Overnight Lorry Park",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.overnightLorryPark",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Harbour / Port / Dock / Dockyard / Slipway / Landing Stage / Pier / Jetty / Pontoon / Terminal / Berthing / Quay",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Passenger Ferry Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock.ferry.passengers",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Non-Tanker Nautical Berthing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock.generalBerth",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Nautical Refuelling Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock.refuelling",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Slipway",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock.slipway",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Ship Passenger Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock.passenger",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Tanker Berthing",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock.tankerBerth",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Vehicular Ferry Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.transport.dock.ferry.vehicles",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Utility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Electricity Sub-Station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.SubStation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Landfill",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.landfill",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Power Station / Energy Production",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.electricity",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Electricity Distribution Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.electricity.distribution",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Electricity Production Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.electricity.production",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Wind Farm",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.electricity.windFarm",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Wind Turbine",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.electricity.windTurbine",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Pump House / Pumping Station / Water Tower",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.water",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water Controlling / Pumping",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.water.pump.control",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water Distribution / Pumping",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.water.pump.distribution",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water Quality Monitoring",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.water.qualityMonitoring",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water Storage",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.water.storage",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Waste Water Distribution / Pumping",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.water.waste",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Telecommunication",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.telecoms",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Telecommunications Mast",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.telecoms.mast",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Telephone Exchange",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.telecoms.exhange",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water / Waste Water / Sewage Treatment Works",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.waterTreatment",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Waste Water Treatment",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.waterTreatment.waste",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Water Treatment",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.waterTreatment.water",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Gas / Oil Storage / Distribution",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.oilGas",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Gas Governor",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.oilGas.gasGovernor",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Gas Holder",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.oilGas.gasHolder",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Oil Terminal",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.oilGas.oilTerminal",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other Utility Use",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.other",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cable Terminal Station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.other.cableTerminal",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Observatory",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.other.observatory",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Radar Station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.other.radar",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Satellite Earth Station",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.other.satelliteEarth",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Waste Management",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.wasteManagement",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Telephone Box",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.publicPhone.box",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other Public Telephones",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.publicPhone.other",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Dam",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.utility.dam",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Emergency / Rescue Service",
-              "type": "string"
-            },
-            "value": {
-              "const": "commercial.emergency",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Nautical Navigation Beacon / Light",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.navigation.nautical.beacon",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Aid To Road Navigation",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.navigation.road",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Guide Post",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.navigation.guidePost",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Coastal Protection / Flood Prevention",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.coastal",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Boulder Wall / Sea Wall",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.coastal.wall",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Flood Gate / Flood Sluice Gate / Flood Valve",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.coastal.floodGate",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Groyne",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.coastal.groyne",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rip-Rap",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.coastal.ripRap",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Emergency Support",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.emergency",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Beach Office / First Aid Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.emergency.firstAid",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Emergency Telephone (Non Motorway)",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.emergency.telephone",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fire Alarm Structure / Fire Observation Tower / Fire Beater Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.emergency.fire",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Emergency Equipment Point / Emergency Siren / Warning Flag",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.emergency.warning",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Lifeguard Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.emergency.lifeguard",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "LIfe / Belt / Buoy / Float / Jacket / Safety Rope",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.emergency.floatAids",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Street Furniture",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.streetFurniture",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Agricultural Support Objects",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.agriculture",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Fish Ladder / Lock / Pen / Trap",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.agriculture.fishPen",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Livestock Pen / Dip",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.agriculture.livestockPen",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Currick",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.agriculture.currick",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Slurry Bed / Pit",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.agriculture.slurry",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Historical Site / Object",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.historic",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Historic Structure / Object",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.historic.structure",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Industrial Support",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Adit / Incline / Level",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.aditIncline",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Caisson / Dry Dock / Grid",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.caissonDock",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Channel / Conveyor / Conduit / Pipe",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.channel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Chimney / Flue",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.chimney",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Crane / Hoist / Winch / Material Elevator",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.crane",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Flare Stack",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.flareStack",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Hopper / Silo / Cistern / Tank",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.siloTank",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Grab / Skip / Other Industrial Waste Machinery / Discharging",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.discharge",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Kiln / Oven / Smelter",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.kiln",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Manhole / Shaft",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.manholeShaft",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Industrial Overflow / Sluice / Valve / Valve Housing",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.overflowSluiceValve",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cooling Tower",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.coolingTower",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Solar Panel / Waterwheel",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.solarPanel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Telephone Pole / Post",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.pylon.telecom",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Electricity Distribution Pole / Pylon",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.industrial.pylon.electricity",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Significant Natural Object",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.natural",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Boundary / Significant / Historic Tree / Pollard",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.natural.tree",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Boundary / Significant Rock / Boulder",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.natural.rock",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Natural Hole (Blow / Shake / Swallow)",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.natural.hole",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Ornamental / Cultural Object",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.ornamental",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mausoleum / Tomb / Grave",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.ornamental.tomb",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Simple Ornamental Object",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.ornamental.object",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Maze",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.ornamental.maze",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sport / Leisure Support",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.leisure",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Butt / Hide",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.leisure.hide",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Gallop / Ride",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.leisure.gallop",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Miniature Railway",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.leisure.modelRailway",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Royal Mail Infrastructure",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.mail",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Postal Box",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.mail.postBox",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Postal Delivery Box / Pouch",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.mail.deliveryBox",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "PO Box",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.mail.POBox",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Additional Mail / Packet Addressee",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.mail.additionalAddressee",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Scientific / Observation Support",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.scientific",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Meteorological Station / Equipment",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.scientific.meteo",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Radar / Satellite Infrastructure",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.scientific.radarSatellite",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Telescope / Observation Infrastructure / Astronomy",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.scientific.astronomy",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Transport Support",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cattle Grid / Ford",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.cattleGridFord",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Elevator / Escalator / Steps",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.stepsLiftEscalator",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Footbridge / Walkway",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.bridge",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Pole / Post / Bollard (Restricting Vehicular Access)",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.post",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Subway / Underpass",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.subway",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Customs Inspection Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.customs",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Lay-By",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.layby",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Level Crossing",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.crossing.vehicles",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mail Pick Up",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.mailPickUp",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Railway Pedestrian Crossing",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.crossing.pedestrian",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Railway Buffer",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.buffer",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rail Drag",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.drag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rail Infrastructure Services",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.infrastructure",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rail Kilometre Distance Marker",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.marker.km",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Railway Lighting",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.lighting",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rail Mile Distance Marker",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.market.mile",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Railway Turntable",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.turntable",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rail Weighbridge",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.weighbridge",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Rail Signalling",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.signals",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Railway Traverse",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.rail.traverse",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Goods Tramway",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.goodsTramway",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Road Drag",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.road.drag",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Vehicle Dip",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.road.vehicleDip",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Road Turntable",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.road.turntable",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Road Mile Distance Marker",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.road.marker.mile",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Road Kilometre Distance Marker",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.road.market.km",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Road Infrastructure Services",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.transport.road.infrastructure",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Unsupported Site",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.unsupported",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cycle Parking Facility",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.unsupported.cycleParking",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Picnic / Barbeque Site",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.unsupported.picnic",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Travelling Persons Site",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.unsupported.travellingPersons",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Shelter (Not Including Bus Shelter)",
-              "type": "string"
-            },
-            "value": {
-              "const": "other.unsupported.shelter",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Street Record",
-              "type": "string"
-            },
-            "value": {
-              "const": "parent.street",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Residential",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Ancillary Building",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.building",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Car Park Space",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.carParkingSpace",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Allocated Parking",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.carParkingSpace.allocated",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Residential dwelling",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Caravan",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.caravan",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Detached",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.house.detached",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Semi-detached",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.house.semiDetached",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Terrace",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.house.terrace",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Flat",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.flat",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "House Boat",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.boat",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Sheltered Accommodation",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.shelteredAccommodation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Privately Owned Holiday Caravan / Chalet",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.dwelling.holiday",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Garage",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.garage",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Lock-Up Garage / Garage Court",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.garage.court",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "House In Multiple Occupation",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.HMO",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "HMO Parent",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.HMO.parent",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "HMO Bedsit / Other Non Self Contained Accommodation",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.HMO.bedsit",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "HMO Not Further Divided",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.HMO.undivided",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Residential Institution",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.institution",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Care / Nursing Home",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.institution.care",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Communal Residence",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.institution.communal",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Non-Commercial Lodgings",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.institution.noncommercial",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Religious Community",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.institution.religious",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Residential Education",
-              "type": "string"
-            },
-            "value": {
-              "const": "residential.institution.education",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Unclassified",
-              "type": "string"
-            },
-            "value": {
-              "const": "unclassified",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Awaiting Classification",
-              "type": "string"
-            },
-            "value": {
-              "const": "unclassified.awaitingclassification",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Pending Internal Investigation",
-              "type": "string"
-            },
-            "value": {
-              "const": "unclassified.pendingInvestigation",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Dual Use",
-              "type": "string"
-            },
-            "value": {
-              "const": "dualUse",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Object of Interest",
-              "type": "string"
-            },
-            "value": {
-              "const": "object",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Archaeological Dig Site",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.archaeological",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Monument",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Obelisk / Milestone / Standing Stone",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.vertical",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Obelisk",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.vertical.obelisk",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Standing Stone",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.vertical.standingStone",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Memorial / Market Cross",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.memorial",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Statue",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.statue",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Castle / Historic Ruin",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.ruin",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other Structure",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.other",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Boundary Stone",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.other.boundaryStone",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cascade / Fountain",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.other.waterFeature",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Permanent Art Display / Sculpture",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.other.art",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Windmill (Inactive)",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.monument.other.windmill",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Stately Home",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.statelyHome",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Underground Feature",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cave",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.cave",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Pothole / Natural Hole",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.hole",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Other Underground Feature",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cellar",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.cellar",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Disused Mine",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.extraction",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mineral Mining / Inactive",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.extraction.mine",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Oil And / Gas Extraction/ Inactive",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.extraction.oilGas",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mineral Quarrying And / Open Extraction / Inactive",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.extraction.quarry",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Well / Spring",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.water",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Spring",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.water.spring",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Well",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.underground.other.water.well",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Place Of Worship",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Religious building",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Abbey",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.abbey",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Cathedral",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.cathedral",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Church",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.church",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Chapel",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.chapel",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Gurdwara",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.gurdwara",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Kingdom Hall",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.kingdomHall",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Lych Gate",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.lychGate",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Mosque",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.mosque",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Minster",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.minster",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Stupa",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.stupa",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Synagogue",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.synagogue",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Temple",
-              "type": "string"
-            },
-            "value": {
-              "const": "object.religious.building.temple",
-              "type": "string"
-            }
-          },
-          "required": [
-            "value",
-            "description"
-          ],
-          "type": "object"
+          "const": "commercial",
+          "description": "Commercial",
+          "type": "string"
+        },
+        {
+          "const": "commercial.abattoir",
+          "description": "Slaughter House / Abattoir",
+          "type": "string"
+        },
+        {
+          "const": "commercial.agriculture",
+          "description": "Agricultural",
+          "type": "string"
+        },
+        {
+          "const": "commercial.agriculture.farm",
+          "description": "Farm / Non-Residential Associated Building",
+          "type": "string"
+        },
+        {
+          "const": "commercial.ancillary",
+          "description": "Ancillary Building",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals",
+          "description": "Animal Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.equestrian",
+          "description": "Equestrian",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.equestrian.racing",
+          "description": "Horse Racing / Breeding Stable",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.equestrian.riding",
+          "description": "Commercial Stabling / Riding",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.kennelsCattery",
+          "description": "Cattery / Kennel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.sanctuary",
+          "description": "Animal / Bird / Marine Sanctuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.sanctuary.animals",
+          "description": "Animal Sanctuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.sanctuary.marine",
+          "description": "Marine Sanctuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.services",
+          "description": "Animal Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.services.quarantine",
+          "description": "Animal Quarantining",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.vet",
+          "description": "Vet / Animal Medical Treatment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community",
+          "description": "Community Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.CCTV",
+          "description": "CCTV",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.cemetery",
+          "description": "Cemetery / Crematorium / Graveyard. In Current Use.",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.Cemetery",
+          "description": "Cemetery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.chapelOfRest",
+          "description": "Chapel Of Rest",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.columbarium",
+          "description": "Columbarium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.crematorium",
+          "description": "Crematorium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.military",
+          "description": "Military Cemetery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.mortuary",
+          "description": "Mortuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.court",
+          "description": "Law Court",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.employment",
+          "description": "Job Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.hall",
+          "description": "Public / Village Hall / Other Community Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.hall.club",
+          "description": "Youth Recreational / Social Club",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.HWRC",
+          "description": "Public Household Waste Recycling Centre (HWRC)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison",
+          "description": "Prison",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison.detention",
+          "description": "HM Detention Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison.secureResidential",
+          "description": "Secure Residential Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison.service",
+          "description": "HM Prison Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.recycling",
+          "description": "Recycling Site",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.religious",
+          "description": "Church Hall / Religious Meeting Place / Hall",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.services",
+          "description": "Community Service Centre / Office",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.wc",
+          "description": "Public Convenience",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education",
+          "description": "Education",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.college",
+          "description": "College",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.college.further",
+          "description": "Further Education",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.college.higher",
+          "description": "Higher Education",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.nursery",
+          "description": "Children's Nursery / Crèche",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.other",
+          "description": "Other Educational Establishment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school",
+          "description": "Preparatory / First / Primary / Infant / Junior / Middle School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.first",
+          "description": "First School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.infant",
+          "description": "Infant School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.junior",
+          "description": "Junior School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.middle",
+          "description": "Middle School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.primary.private",
+          "description": "Non State Primary / Preparatory School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.primary.state",
+          "description": "Primary School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.secondarySchool",
+          "description": "Secondary / High School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.secondarySchool.private",
+          "description": "Non State Secondary School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.secondarySchool.state",
+          "description": "Secondary School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.specialNeeds",
+          "description": "Special Needs Establishment.",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.university",
+          "description": "University",
+          "type": "string"
+        },
+        {
+          "const": "commercial.emergency",
+          "description": "Emergency / Rescue Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish",
+          "description": "Fishery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.farm",
+          "description": "Fish Farming",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.hatchery",
+          "description": "Fish Hatchery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.oysters",
+          "description": "Oyster / Mussel Bed",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.processing",
+          "description": "Fish Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest",
+          "description": "Hotel / Motel / Boarding / Guest House",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.hostel",
+          "description": "Boarding / Guest House / Bed And Breakfast / Youth Hostel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.hostel.youth",
+          "description": "Youth Hostel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.hotel",
+          "description": "Hotel/Motel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.shortLet",
+          "description": "Holiday Let/Accommodation/Short-Term Let Other Than CH01",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture",
+          "description": "Horticulture",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture.smallholding",
+          "description": "Smallholding",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture.vineyard",
+          "description": "Vineyard",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture.watercress",
+          "description": "Watercress Bed",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial",
+          "description": "Industrial Applicable to manufacturing, engineering, maintenance, storage / wholesale distribution and extraction sites",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.distribution",
+          "description": "Wholesale Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.distribution.solidFuel",
+          "description": "Solid Fuel Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.distribution.timber",
+          "description": "Timber Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction",
+          "description": "Mineral / Ore Working / Quarry / Mine",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.distribution",
+          "description": "Mineral Distribution / Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.mining",
+          "description": "Mineral Mining / Active",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.oilGas",
+          "description": "Oil / Gas Extraction / Active",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.processing",
+          "description": "Mineral Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.quarrying",
+          "description": "Mineral Quarrying / Open Extraction / Active",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.incineration",
+          "description": "Incinerator / Waste Transfer Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light",
+          "description": "Workshop / Light Industrial",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.garage",
+          "description": "Servicing Garage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage",
+          "description": "Warehouse / Store / Storage Depot",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.crops",
+          "description": "Crop Handling / Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.post",
+          "description": "Postal Sorting / Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.solidFuel",
+          "description": "Solid Fuel Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.timber",
+          "description": "Timber Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.maintenanceDepot",
+          "description": "Maintenance Depot",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing",
+          "description": "Factory/Manufacturing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.aircraft",
+          "description": "Aircraft Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.beer",
+          "description": "Brewery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.boats",
+          "description": "Boat Building",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.bricks",
+          "description": "Brick Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.cement",
+          "description": "Cement Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.chemicals",
+          "description": "Chemical Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.cider",
+          "description": "Cider Manufacture",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.dairy",
+          "description": "Dairy Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.distillery",
+          "description": "Distillery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.flour",
+          "description": "Flour Mill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.food",
+          "description": "Food Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.glass",
+          "description": "Glassworks",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.hops",
+          "description": "Oast House",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.oil",
+          "description": "Oil Refining",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.other",
+          "description": "Manufacturing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.paper",
+          "description": "Paper Mill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.pottery",
+          "description": "Pottery Manufacturing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.printing",
+          "description": "Printing Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.ships",
+          "description": "Shipyard",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.steel",
+          "description": "Steel Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.sugar",
+          "description": "Sugar Refinery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.timber",
+          "description": "Timber Mill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.wine",
+          "description": "Winery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.recycling",
+          "description": "Recycling Plant",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure",
+          "description": "Leisure - Applicable to recreational sites and enterprises",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.amusements",
+          "description": "Amusements",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.amusements.pier",
+          "description": "Leisure Pier",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.arena",
+          "description": "Arena / Stadium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.arena.showground",
+          "description": "Showground",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.arena.stadium",
+          "description": "Stadium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.beachHut",
+          "description": "Beach Hut (Recreational, Non-Residential Use Only)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.club.private",
+          "description": "Licensed Private Members' Club",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.club.social",
+          "description": "Recreational / Social Club",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment",
+          "description": "Bingo Hall / Cinema / Conference / Exhibition Centre / Theatre / Concert Hall",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.cinema",
+          "description": "Cinema",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.exhibition",
+          "description": "Conference / Exhibition Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.mixed",
+          "description": "Entertainment Complex",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.theatre",
+          "description": "Theatre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday",
+          "description": "Holiday / Campsite",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.accommodation",
+          "description": "Holiday Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.camping",
+          "description": "Camping",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.caravanning",
+          "description": "Caravanning",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.centre",
+          "description": "Holiday Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.youth",
+          "description": "Youth Organisation Camp",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.library",
+          "description": "Library",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.library.readingRoom",
+          "description": "Reading Room",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum",
+          "description": "Museum / Gallery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.art",
+          "description": "Art Centre / Gallery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.aviation",
+          "description": "Aviation Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.heritage",
+          "description": "Heritage Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.industrial",
+          "description": "Industrial Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.maritime",
+          "description": "Maritime Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.military",
+          "description": "Military Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.science",
+          "description": "Science Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.transport",
+          "description": "Transport Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.amusement",
+          "description": "Amusement Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.aquatic",
+          "description": "Aquatic Attraction",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.model",
+          "description": "Model Village Site",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.wildlife",
+          "description": "Wildlife / Zoological Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.zoo",
+          "description": "Zoo / Theme Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport",
+          "description": "Indoor / Outdoor Leisure / Sporting Activity / Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.athletics",
+          "description": "Athletics Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.bowls",
+          "description": "Bowls Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.centre",
+          "description": "Activity / Leisure / Sports Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.cricket",
+          "description": "Cricket Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.curling",
+          "description": "Curling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.cycling",
+          "description": "Cycling Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.dogracing",
+          "description": "Greyhound Racing Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.equestrian",
+          "description": "Equestrian Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.firing",
+          "description": "Civilian Firing Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.fishing",
+          "description": "Fishing / Angling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.football",
+          "description": "Football Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.gliding",
+          "description": "Gliding Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.golf",
+          "description": "Golf Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.historicVehicles",
+          "description": "Historic Vessel / Aircraft / Vehicle",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.hockey",
+          "description": "Hockey Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.horseracing",
+          "description": "Horse Racing Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.model",
+          "description": "Model Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.motor",
+          "description": "Motor Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.playingField",
+          "description": "Playing Field",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.racquet",
+          "description": "Racquet Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.recreationGround",
+          "description": "Recreation Ground",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.rugby",
+          "description": "Rugby Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.shinty",
+          "description": "Shinty Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.skateboarding",
+          "description": "Skateboarding Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.swimming",
+          "description": "Diving / Swimming Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.tennis",
+          "description": "Public Tennis Court",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.tenpin",
+          "description": "Tenpin Bowling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.water",
+          "description": "Water Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.wildlife",
+          "description": "Wildlife Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.winter",
+          "description": "Winter Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical",
+          "description": "Medical",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.assessment",
+          "description": "Assessment / Development Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.care",
+          "description": "Hospital / Hospice",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.care.home",
+          "description": "Care home/Hospice",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.care.hospital",
+          "description": "Hospital",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.dentist",
+          "description": "Dentist",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.GP",
+          "description": "General Practice Surgery / Clinic",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.healthCentre",
+          "description": "Health Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.healthServices",
+          "description": "Health Care Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.lab",
+          "description": "Medical / Testing / Research Laboratory",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.professional",
+          "description": "Professional Medical Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office",
+          "description": "Office",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.broadcasting",
+          "description": "Broadcasting (TV / Radio)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace",
+          "description": "Office / Work Studio",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.embassy",
+          "description": "Embassy /, High Commission / Consulate",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.film",
+          "description": "Film Studio",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.gov.local",
+          "description": "Local Government Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.gov.national",
+          "description": "Central Government Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail",
+          "description": "Retail",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.atm",
+          "description": "Automated Teller Machine (ATM)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.drinking",
+          "description": "Public House / Bar / Nightclub",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.financial",
+          "description": "Bank / Financial Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.fuel",
+          "description": "Petrol Filling Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.licensedPremises",
+          "description": "Other Licensed Premise / Vendor",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market",
+          "description": "Market (Indoor / Outdoor)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market.fish",
+          "description": "Fish Market",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market.fruit",
+          "description": "Fruit / Vegetable Market",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market.livestock",
+          "description": "Livestock Market",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.post",
+          "description": "Post Office",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.restaurant",
+          "description": "Restaurant / Cafeteria",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.services",
+          "description": "Retail Service Agent",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.shop",
+          "description": "Shop",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.shop.gardenCentre",
+          "description": "Garden Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.showroom",
+          "description": "Shop / Showroom",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.takeaway",
+          "description": "Fast Food Outlet / Takeaway (Hot / Cold)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.storageLand",
+          "description": "Storage Land",
+          "type": "string"
+        },
+        {
+          "const": "commercial.storageLand.building",
+          "description": "Builders' Yard",
+          "type": "string"
+        },
+        {
+          "const": "commercial.storageLand.general",
+          "description": "General Storage Land",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport",
+          "description": "Transport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air",
+          "description": "Airfield / Airstrip / Airport / Air Transport Infrastructure Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.airfield",
+          "description": "Airfield",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.airport",
+          "description": "Airport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.helicopterStation",
+          "description": "Helicopter Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.heliport",
+          "description": "Heliport / Helipad",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.infrastructure",
+          "description": "Air Transport Infrastructure Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.passengerTerminal",
+          "description": "Air Passenger Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.bus",
+          "description": "Bus Shelter",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock",
+          "description": "Harbour / Port / Dock / Dockyard / Slipway / Landing Stage / Pier / Jetty / Pontoon / Terminal / Berthing / Quay",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.ferry.passengers",
+          "description": "Passenger Ferry Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.ferry.vehicles",
+          "description": "Vehicular Ferry Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.generalBerth",
+          "description": "Non-Tanker Nautical Berthing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.passenger",
+          "description": "Ship Passenger Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.refuelling",
+          "description": "Nautical Refuelling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.slipway",
+          "description": "Slipway",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.tankerBerth",
+          "description": "Tanker Berthing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight",
+          "description": "Goods Freight Handling / Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.air",
+          "description": "Air Freight Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.container",
+          "description": "Container Freight",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.rail",
+          "description": "Rail Freight Transport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.road",
+          "description": "Road Freight Transport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure",
+          "description": "Transport Related Infrastructure",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.aqueduct",
+          "description": "Aqueduct",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.lock",
+          "description": "Lock",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.weighing",
+          "description": "Weighbridge / Load Gauge",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.weir",
+          "description": "Weir",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.marina",
+          "description": "Marina",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.mooring",
+          "description": "Mooring",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.overnightLorryPark",
+          "description": "Overnight Lorry Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking",
+          "description": "Car / Coach / Commercial Vehicle / Taxi Parking / Park And Ride Site",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.car",
+          "description": "Public Car Parking",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.coach",
+          "description": "Public Coach Parking",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.commercialVehicle",
+          "description": "Public Commercial Vehicle Parking",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.parkAndRide",
+          "description": "Public Park And Ride",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.railAsset",
+          "description": "Railway Asset",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.storage",
+          "description": "Vehicle Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.storage.boat",
+          "description": "Boat Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.storage.bus",
+          "description": "Bus / Coach Depot",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal",
+          "description": "Station / Interchange / Terminal / Halt",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal.train",
+          "description": "Train station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal.bus",
+          "description": "Bus station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal.vehicularRail",
+          "description": "Vehicular Rail Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track",
+          "description": "Transport Track / Way",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track.cable",
+          "description": "Chair Lift / Cable Car / Ski Tow",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track.cliff",
+          "description": "Cliff Railway",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track.monorail",
+          "description": "Monorail",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility",
+          "description": "Utility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.dam",
+          "description": "Dam",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity",
+          "description": "Power Station / Energy Production",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.distribution",
+          "description": "Electricity Distribution Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.production",
+          "description": "Electricity Production Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.windFarm",
+          "description": "Wind Farm",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.windTurbine",
+          "description": "Wind Turbine",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.landfill",
+          "description": "Landfill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas",
+          "description": "Gas / Oil Storage / Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas.gasGovernor",
+          "description": "Gas Governor",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas.gasHolder",
+          "description": "Gas Holder",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas.oilTerminal",
+          "description": "Oil Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other",
+          "description": "Other Utility Use",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.cableTerminal",
+          "description": "Cable Terminal Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.observatory",
+          "description": "Observatory",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.radar",
+          "description": "Radar Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.satelliteEarth",
+          "description": "Satellite Earth Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.publicPhone.box",
+          "description": "Telephone Box",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.publicPhone.other",
+          "description": "Other Public Telephones",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.SubStation",
+          "description": "Electricity Sub-Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.telecoms",
+          "description": "Telecommunication",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.telecoms.exchange",
+          "description": "Telephone Exchange",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.telecoms.mast",
+          "description": "Telecommunications Mast",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.wasteManagement",
+          "description": "Waste Management",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water",
+          "description": "Pump House / Pumping Station / Water Tower",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.pump.control",
+          "description": "Water Controlling / Pumping",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.pump.distribution",
+          "description": "Water Distribution / Pumping",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.qualityMonitoring",
+          "description": "Water Quality Monitoring",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.storage",
+          "description": "Water Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.waterTreatment",
+          "description": "Water / Waste Water / Sewage Treatment Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.waterTreatment.waste",
+          "description": "Waste Water Treatment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.waterTreatment.water",
+          "description": "Water Treatment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.waste",
+          "description": "Waste Water Distribution / Pumping",
+          "type": "string"
+        },
+        {
+          "const": "dualUse",
+          "description": "Dual Use",
+          "type": "string"
+        },
+        {
+          "const": "object",
+          "description": "Object of Interest",
+          "type": "string"
+        },
+        {
+          "const": "object.archaeological",
+          "description": "Archaeological Dig Site",
+          "type": "string"
+        },
+        {
+          "const": "object.monument",
+          "description": "Monument",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.memorial",
+          "description": "Memorial / Market Cross",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other",
+          "description": "Other Structure",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.art",
+          "description": "Permanent Art Display / Sculpture",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.boundaryStone",
+          "description": "Boundary Stone",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.waterFeature",
+          "description": "Cascade / Fountain",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.windmill",
+          "description": "Windmill (Inactive)",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.ruin",
+          "description": "Castle / Historic Ruin",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.statue",
+          "description": "Statue",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.vertical",
+          "description": "Obelisk / Milestone / Standing Stone",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.vertical.obelisk",
+          "description": "Obelisk",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.vertical.standingStone",
+          "description": "Standing Stone",
+          "type": "string"
+        },
+        {
+          "const": "object.religious",
+          "description": "Place Of Worship",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building",
+          "description": "Religious building",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.abbey",
+          "description": "Abbey",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.cathedral",
+          "description": "Cathedral",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.chapel",
+          "description": "Chapel",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.church",
+          "description": "Church",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.gurdwara",
+          "description": "Gurdwara",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.kingdomHall",
+          "description": "Kingdom Hall",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.lychGate",
+          "description": "Lych Gate",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.minster",
+          "description": "Minster",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.mosque",
+          "description": "Mosque",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.stupa",
+          "description": "Stupa",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.synagogue",
+          "description": "Synagogue",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.temple",
+          "description": "Temple",
+          "type": "string"
+        },
+        {
+          "const": "object.statelyHome",
+          "description": "Stately Home",
+          "type": "string"
+        },
+        {
+          "const": "object.underground",
+          "description": "Underground Feature",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.cave",
+          "description": "Cave",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.hole",
+          "description": "Pothole / Natural Hole",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other",
+          "description": "Other Underground Feature",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.cellar",
+          "description": "Cellar",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction",
+          "description": "Disused Mine",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction.mine",
+          "description": "Mineral Mining / Inactive",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction.oilGas",
+          "description": "Oil And / Gas Extraction/ Inactive",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction.quarry",
+          "description": "Mineral Quarrying And / Open Extraction / Inactive",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.water",
+          "description": "Well / Spring",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.water.spring",
+          "description": "Spring",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.water.well",
+          "description": "Well",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture",
+          "description": "Agricultural Support Objects",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.currick",
+          "description": "Currick",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.fishPen",
+          "description": "Fish Ladder / Lock / Pen / Trap",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.livestockPen",
+          "description": "Livestock Pen / Dip",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.slurry",
+          "description": "Slurry Bed / Pit",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal",
+          "description": "Coastal Protection / Flood Prevention",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.floodGate",
+          "description": "Flood Gate / Flood Sluice Gate / Flood Valve",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.groyne",
+          "description": "Groyne",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.ripRap",
+          "description": "Rip-Rap",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.wall",
+          "description": "Boulder Wall / Sea Wall",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency",
+          "description": "Emergency Support",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.fire",
+          "description": "Fire Alarm Structure / Fire Observation Tower / Fire Beater Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.firstAid",
+          "description": "Beach Office / First Aid Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.floatAids",
+          "description": "LIfe / Belt / Buoy / Float / Jacket / Safety Rope",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.lifeguard",
+          "description": "Lifeguard Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.telephone",
+          "description": "Emergency Telephone (Non Motorway)",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.warning",
+          "description": "Emergency Equipment Point / Emergency Siren / Warning Flag",
+          "type": "string"
+        },
+        {
+          "const": "other.historic",
+          "description": "Historical Site / Object",
+          "type": "string"
+        },
+        {
+          "const": "other.historic.structure",
+          "description": "Historic Structure / Object",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial",
+          "description": "Industrial Support",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.aditIncline",
+          "description": "Adit / Incline / Level",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.caissonDock",
+          "description": "Caisson / Dry Dock / Grid",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.channel",
+          "description": "Channel / Conveyor / Conduit / Pipe",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.chimney",
+          "description": "Chimney / Flue",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.coolingTower",
+          "description": "Cooling Tower",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.crane",
+          "description": "Crane / Hoist / Winch / Material Elevator",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.discharge",
+          "description": "Grab / Skip / Other Industrial Waste Machinery / Discharging",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.flareStack",
+          "description": "Flare Stack",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.kiln",
+          "description": "Kiln / Oven / Smelter",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.manholeShaft",
+          "description": "Manhole / Shaft",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.overflowSluiceValve",
+          "description": "Industrial Overflow / Sluice / Valve / Valve Housing",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.pylon.electricity",
+          "description": "Electricity Distribution Pole / Pylon",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.pylon.telecom",
+          "description": "Telephone Pole / Post",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.siloTank",
+          "description": "Hopper / Silo / Cistern / Tank",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.solarPanel",
+          "description": "Solar Panel / Waterwheel",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure",
+          "description": "Sport / Leisure Support",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure.gallop",
+          "description": "Gallop / Ride",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure.hide",
+          "description": "Butt / Hide",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure.modelRailway",
+          "description": "Miniature Railway",
+          "type": "string"
+        },
+        {
+          "const": "other.mail",
+          "description": "Royal Mail Infrastructure",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.additionalAddressee",
+          "description": "Additional Mail / Packet Addressee",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.deliveryBox",
+          "description": "Postal Delivery Box / Pouch",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.POBox",
+          "description": "PO Box",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.postBox",
+          "description": "Postal Box",
+          "type": "string"
+        },
+        {
+          "const": "other.natural",
+          "description": "Significant Natural Object",
+          "type": "string"
+        },
+        {
+          "const": "other.natural.hole",
+          "description": "Natural Hole (Blow / Shake / Swallow)",
+          "type": "string"
+        },
+        {
+          "const": "other.natural.rock",
+          "description": "Boundary / Significant Rock / Boulder",
+          "type": "string"
+        },
+        {
+          "const": "other.natural.tree",
+          "description": "Boundary / Significant / Historic Tree / Pollard",
+          "type": "string"
+        },
+        {
+          "const": "other.navigation.guidePost",
+          "description": "Guide Post",
+          "type": "string"
+        },
+        {
+          "const": "other.navigation.nautical.beacon",
+          "description": "Nautical Navigation Beacon / Light",
+          "type": "string"
+        },
+        {
+          "const": "other.navigation.road",
+          "description": "Aid To Road Navigation",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental",
+          "description": "Ornamental / Cultural Object",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental.maze",
+          "description": "Maze",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental.object",
+          "description": "Simple Ornamental Object",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental.tomb",
+          "description": "Mausoleum / Tomb / Grave",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific",
+          "description": "Scientific / Observation Support",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific.astronomy",
+          "description": "Telescope / Observation Infrastructure / Astronomy",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific.meteo",
+          "description": "Meteorological Station / Equipment",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific.radarSatellite",
+          "description": "Radar / Satellite Infrastructure",
+          "type": "string"
+        },
+        {
+          "const": "other.streetFurniture",
+          "description": "Street Furniture",
+          "type": "string"
+        },
+        {
+          "const": "other.transport",
+          "description": "Transport Support",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.bridge",
+          "description": "Footbridge / Walkway",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.cattleGridFord",
+          "description": "Cattle Grid / Ford",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.customs",
+          "description": "Customs Inspection Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.goodsTramway",
+          "description": "Goods Tramway",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.layby",
+          "description": "Lay-By",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.mailPickUp",
+          "description": "Mail Pick Up",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.post",
+          "description": "Pole / Post / Bollard (Restricting Vehicular Access)",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.buffer",
+          "description": "Railway Buffer",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.crossing.pedestrian",
+          "description": "Railway Pedestrian Crossing",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.crossing.vehicles",
+          "description": "Level Crossing",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.drag",
+          "description": "Rail Drag",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.infrastructure",
+          "description": "Rail Infrastructure Services",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.lighting",
+          "description": "Railway Lighting",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.marker.km",
+          "description": "Rail Kilometre Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.market.mile",
+          "description": "Rail Mile Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.signals",
+          "description": "Rail Signalling",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.traverse",
+          "description": "Railway Traverse",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.turntable",
+          "description": "Railway Turntable",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.weighbridge",
+          "description": "Rail Weighbridge",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.drag",
+          "description": "Road Drag",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.infrastructure",
+          "description": "Road Infrastructure Services",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.marker.mile",
+          "description": "Road Mile Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.market.km",
+          "description": "Road Kilometre Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.turntable",
+          "description": "Road Turntable",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.vehicleDip",
+          "description": "Vehicle Dip",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.stepsLiftEscalator",
+          "description": "Elevator / Escalator / Steps",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.subway",
+          "description": "Subway / Underpass",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported",
+          "description": "Unsupported Site",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.cycleParking",
+          "description": "Cycle Parking Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.picnic",
+          "description": "Picnic / Barbecue Site",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.shelter",
+          "description": "Shelter (Not Including Bus Shelter)",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.travellingPersons",
+          "description": "Travelling Persons Site",
+          "type": "string"
+        },
+        {
+          "const": "parent.street",
+          "description": "Street Record",
+          "type": "string"
+        },
+        {
+          "const": "residential",
+          "description": "Residential",
+          "type": "string"
+        },
+        {
+          "const": "residential.building",
+          "description": "Ancillary Building",
+          "type": "string"
+        },
+        {
+          "const": "residential.carParkingSpace",
+          "description": "Car Park Space",
+          "type": "string"
+        },
+        {
+          "const": "residential.carParkingSpace.allocated",
+          "description": "Allocated Parking",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling",
+          "description": "Residential dwelling",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.boat",
+          "description": "House Boat",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.caravan",
+          "description": "Caravan",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.flat",
+          "description": "Flat",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.holiday",
+          "description": "Privately Owned Holiday Caravan / Chalet",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.house.detached",
+          "description": "Detached",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.house.semiDetached",
+          "description": "Semi-detached",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.house.terrace",
+          "description": "Terrace",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.shelteredAccommodation",
+          "description": "Sheltered Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "residential.garage",
+          "description": "Garage",
+          "type": "string"
+        },
+        {
+          "const": "residential.garage.court",
+          "description": "Lock-Up Garage / Garage Court",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO",
+          "description": "House In Multiple Occupation",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO.bedsit",
+          "description": "HMO Bedsit / Other Non Self Contained Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO.parent",
+          "description": "HMO Parent",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO.undivided",
+          "description": "HMO Not Further Divided",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution",
+          "description": "Residential Institution",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.care",
+          "description": "Care / Nursing Home",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.communal",
+          "description": "Communal Residence",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.education",
+          "description": "Residential Education",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.noncommercial",
+          "description": "Non-Commercial Lodgings",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.religious",
+          "description": "Religious Community",
+          "type": "string"
+        },
+        {
+          "const": "unclassified",
+          "description": "Unclassified",
+          "type": "string"
+        },
+        {
+          "const": "unclassified.awaitingclassification",
+          "description": "Awaiting Classification",
+          "type": "string"
+        },
+        {
+          "const": "unclassified.pendingInvestigation",
+          "description": "Pending Internal Investigation",
+          "type": "string"
         }
       ],
       "description": "Property types derived from Basic Land and Property Unit (BLPU) classification codes"
@@ -13227,7 +5549,6 @@
       "type": "object"
     },
     "ProposedAddress": {
-      "$id": "#ProposedAddress",
       "additionalProperties": false,
       "description": "Address information for sites without a known Unique Property Reference Number (UPRN)",
       "properties": {
@@ -13244,6 +5565,7 @@
           "type": "string"
         },
         "title": {
+          "description": "Single line address description",
           "type": "string"
         },
         "x": {
@@ -13262,6 +5584,615 @@
         "title",
         "x",
         "y"
+      ],
+      "title": "#ProposedAddress",
+      "type": "object"
+    },
+    "PrototypeFileType": {
+      "$id": "#FileType",
+      "anyOf": [
+        {
+          "const": "accessRoadsRightsOfWayDetails",
+          "description": "Details of impact on access, roads, and rights of way",
+          "type": "string"
+        },
+        {
+          "const": "affordableHousingStatement",
+          "description": "Affordable housing statement",
+          "type": "string"
+        },
+        {
+          "const": "arboriculturistReport",
+          "description": "Arboriculturist report",
+          "type": "string"
+        },
+        {
+          "const": "bankStatement",
+          "description": "Bank statement",
+          "type": "string"
+        },
+        {
+          "const": "basementImpactStatement",
+          "description": "Basement impact statement",
+          "type": "string"
+        },
+        {
+          "const": "bioaerosolAssessment",
+          "description": "Bio-aerosol assessment",
+          "type": "string"
+        },
+        {
+          "const": "birdstrikeRiskManagementPlan",
+          "description": "Birdstrike risk management plan",
+          "type": "string"
+        },
+        {
+          "const": "boreholeOrTrialPitAnalysis",
+          "description": "Borehole or trial pit analysis",
+          "type": "string"
+        },
+        {
+          "const": "buildingControlCertificate",
+          "description": "Building control certificate",
+          "type": "string"
+        },
+        {
+          "const": "conditionSurvey",
+          "description": "Structural or building condition survey",
+          "type": "string"
+        },
+        {
+          "const": "constructionInvoice",
+          "description": "Construction invoice",
+          "type": "string"
+        },
+        {
+          "const": "contaminationReport",
+          "description": "Contamination report",
+          "type": "string"
+        },
+        {
+          "const": "councilTaxBill",
+          "description": "Council tax bill",
+          "type": "string"
+        },
+        {
+          "const": "crimePreventionStrategy",
+          "description": "Crime prevention strategy",
+          "type": "string"
+        },
+        {
+          "const": "designAndAccessStatement",
+          "description": "Design and Access Statement",
+          "type": "string"
+        },
+        {
+          "const": "disabilityExemptionEvidence",
+          "description": "Evidence for application fee exemption - disability",
+          "type": "string"
+        },
+        {
+          "const": "ecologyReport",
+          "description": "Ecology report",
+          "type": "string"
+        },
+        {
+          "const": "elevations.existing",
+          "description": "Elevations - existing",
+          "type": "string"
+        },
+        {
+          "const": "elevations.proposed",
+          "description": "Elevations - proposed",
+          "type": "string"
+        },
+        {
+          "const": "emissionsMitigationAndMonitoringScheme",
+          "description": "Scheme for mitigation and monitoring of emissions (dust, odour and vibrations)",
+          "type": "string"
+        },
+        {
+          "const": "energyStatement",
+          "description": "Energy statement",
+          "type": "string"
+        },
+        {
+          "const": "environmentalImpactAssessment",
+          "description": "Environmental Impact Assessment (EIA)",
+          "type": "string"
+        },
+        {
+          "const": "externalMaterialsDetails",
+          "description": "External materials details",
+          "type": "string"
+        },
+        {
+          "const": "fireSafetyReport",
+          "description": "Fire safety report",
+          "type": "string"
+        },
+        {
+          "const": "floodRiskAssessment",
+          "description": "Flood risk assessment (FRA)",
+          "type": "string"
+        },
+        {
+          "const": "floorPlan.existing",
+          "description": "Floor plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "floorPlan.proposed",
+          "description": "Floor plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "foulDrainageAssessment",
+          "description": "Foul drainage assessment",
+          "type": "string"
+        },
+        {
+          "const": "geodiversityAssessment",
+          "description": "Geodiversity assessment",
+          "type": "string"
+        },
+        {
+          "const": "hedgerowsInformation",
+          "description": "Plans showing the stretches of hedgerows to be removed",
+          "type": "string"
+        },
+        {
+          "const": "hedgerowsInformation.plantingDate",
+          "description": "Evidence of the date of planting of the removed hedgerows",
+          "type": "string"
+        },
+        {
+          "const": "heritageStatement",
+          "description": "Heritage Statement",
+          "type": "string"
+        },
+        {
+          "const": "hydrologicalAssessment",
+          "description": "Hydrological and hydrogeological assessment",
+          "type": "string"
+        },
+        {
+          "const": "hydrologyReport",
+          "description": "Hydrology report",
+          "type": "string"
+        },
+        {
+          "const": "internalElevations",
+          "description": "Internal elevations",
+          "type": "string"
+        },
+        {
+          "const": "internalSections",
+          "description": "Internal sections",
+          "type": "string"
+        },
+        {
+          "const": "joinersReport",
+          "description": "Joiner's report",
+          "type": "string"
+        },
+        {
+          "const": "joinerySections",
+          "description": "Joinery section report",
+          "type": "string"
+        },
+        {
+          "const": "landContaminationAssessment",
+          "description": "Land contamination assessment",
+          "type": "string"
+        },
+        {
+          "const": "landscapeAndVisualImpactAssessment",
+          "description": "Landscape and visual impact assessment (LVIA)",
+          "type": "string"
+        },
+        {
+          "const": "landscapeStrategy",
+          "description": "Landscape strategy or landscape plan",
+          "type": "string"
+        },
+        {
+          "const": "lightingAssessment",
+          "description": "Lighting assessment",
+          "type": "string"
+        },
+        {
+          "const": "litterVerminAndBirdControlDetails",
+          "description": "Details of litter, vermin and bird control",
+          "type": "string"
+        },
+        {
+          "const": "locationPlan",
+          "description": "Location plan",
+          "type": "string"
+        },
+        {
+          "const": "methodStatement",
+          "description": "Method statement",
+          "type": "string"
+        },
+        {
+          "const": "mineralsAndWasteAssessment",
+          "description": "Minerals and waste assessment",
+          "type": "string"
+        },
+        {
+          "const": "necessaryInformation",
+          "description": "Information the authority considers necessary for the application",
+          "type": "string"
+        },
+        {
+          "const": "newDwellingsSchedule",
+          "description": "New dwellings schedule",
+          "type": "string"
+        },
+        {
+          "const": "noiseAssessment",
+          "description": "Noise assessment",
+          "type": "string"
+        },
+        {
+          "const": "openSpaceAssessment",
+          "description": "Open space assessment",
+          "type": "string"
+        },
+        {
+          "const": "otherDocument",
+          "description": "Other - document",
+          "type": "string"
+        },
+        {
+          "const": "otherDrawing",
+          "description": "Other - drawing",
+          "type": "string"
+        },
+        {
+          "const": "otherEvidence",
+          "description": "Other - evidence or correspondence",
+          "type": "string"
+        },
+        {
+          "const": "otherSupporting",
+          "description": "Other - supporting document",
+          "type": "string"
+        },
+        {
+          "const": "parkingPlan",
+          "description": "Parking plan",
+          "type": "string"
+        },
+        {
+          "const": "photographs.existing",
+          "description": "Photographs - existing",
+          "type": "string"
+        },
+        {
+          "const": "photographs.proposed",
+          "description": "Photographs - proposed",
+          "type": "string"
+        },
+        {
+          "const": "planningStatement",
+          "description": "Planning statement",
+          "type": "string"
+        },
+        {
+          "const": "recycleWasteStorageDetails",
+          "description": "Recyclable waste storage details",
+          "type": "string"
+        },
+        {
+          "const": "relevantInformation",
+          "description": "Information the applicant considers relevant to the application",
+          "type": "string"
+        },
+        {
+          "const": "residentialUnitsDetails",
+          "description": "Residential units details",
+          "type": "string"
+        },
+        {
+          "const": "roofPlan.existing",
+          "description": "Roof plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "roofPlan.proposed",
+          "description": "Roof plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "sections.existing",
+          "description": "Sections - existing",
+          "type": "string"
+        },
+        {
+          "const": "sections.proposed",
+          "description": "Sections - proposed",
+          "type": "string"
+        },
+        {
+          "const": "sitePlan.existing",
+          "description": "Site plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "sitePlan.proposed",
+          "description": "Site plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "sketchPlan",
+          "description": "Sketch plan",
+          "type": "string"
+        },
+        {
+          "const": "statementOfCommunityInvolvement",
+          "description": "Statement of community involvement",
+          "type": "string"
+        },
+        {
+          "const": "statutoryDeclaration",
+          "description": "Statutory declaration",
+          "type": "string"
+        },
+        {
+          "const": "storageTreatmentAndWasteDisposalDetails",
+          "description": "Details of storage treatment or disposal of waste",
+          "type": "string"
+        },
+        {
+          "const": "streetScene",
+          "description": "Street scene drawing",
+          "type": "string"
+        },
+        {
+          "const": "subsidenceReport",
+          "description": "Subsidence report",
+          "type": "string"
+        },
+        {
+          "const": "sunlightAndDaylightReport",
+          "description": "Sunlight and daylight report",
+          "type": "string"
+        },
+        {
+          "const": "sustainabilityStatement",
+          "description": "Sustainability statement",
+          "type": "string"
+        },
+        {
+          "const": "technicalEvidence",
+          "description": "Technical evidence",
+          "type": "string"
+        },
+        {
+          "const": "technicalSpecification",
+          "description": "Technical specification",
+          "type": "string"
+        },
+        {
+          "const": "tenancyAgreement",
+          "description": "Tenancy agreement",
+          "type": "string"
+        },
+        {
+          "const": "tenancyInvoice",
+          "description": "Tenancy invoice",
+          "type": "string"
+        },
+        {
+          "const": "townCentreImpactAssessment",
+          "description": "Town centre uses - Impact assessment",
+          "type": "string"
+        },
+        {
+          "const": "townCentreSequentialAssessment",
+          "description": "Town centre uses - Sequential assessment",
+          "type": "string"
+        },
+        {
+          "const": "transportAssessment",
+          "description": "Transport assessment",
+          "type": "string"
+        },
+        {
+          "const": "travelPlan",
+          "description": "Travel plan",
+          "type": "string"
+        },
+        {
+          "const": "treeAndHedgeLocation",
+          "description": "Location of trees and hedges",
+          "type": "string"
+        },
+        {
+          "const": "treeAndHedgeRemovedOrPruned",
+          "description": "Removed or pruned trees and hedges",
+          "type": "string"
+        },
+        {
+          "const": "treeCanopyCalculator",
+          "description": "Tree canopy calculator",
+          "type": "string"
+        },
+        {
+          "const": "treeConditionReport",
+          "description": "Tree condition report",
+          "type": "string"
+        },
+        {
+          "const": "treePlan",
+          "description": "Tree plan",
+          "type": "string"
+        },
+        {
+          "const": "treesReport",
+          "description": "Trees report",
+          "type": "string"
+        },
+        {
+          "const": "unitPlan.existing",
+          "description": "Unit plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "unitPlan.proposed",
+          "description": "Unit plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "usePlan.existing",
+          "description": "Use plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "usePlan.proposed",
+          "description": "Use plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "utilityBill",
+          "description": "Utility bill",
+          "type": "string"
+        },
+        {
+          "const": "utilitiesStatement",
+          "description": "Utilities statement",
+          "type": "string"
+        },
+        {
+          "const": "ventilationStatement",
+          "description": "Ventilation or extraction statement",
+          "type": "string"
+        },
+        {
+          "const": "viabilityAppraisal",
+          "description": "Viability Appraisal",
+          "type": "string"
+        },
+        {
+          "const": "visualisations",
+          "description": "Visualisations",
+          "type": "string"
+        },
+        {
+          "const": "wasteAndRecyclingStrategy",
+          "description": "Waste and recycling strategy",
+          "type": "string"
+        },
+        {
+          "const": "wasteStorageDetails",
+          "description": "Waste storage details",
+          "type": "string"
+        },
+        {
+          "const": "waterEnvironmentAssessment",
+          "description": "Water environment assessment",
+          "type": "string"
+        }
+      ],
+      "description": "Types of planning documents and drawings"
+    },
+    "PrototypePlanXMetadata": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/UUID",
+          "description": "Unique identifier for this application"
+        },
+        "organisation": {
+          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
+          "maxLength": 4,
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/URL"
+        },
+        "service": {
+          "additionalProperties": false,
+          "properties": {
+            "fee": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FeeExplanation"
+                },
+                {
+                  "$ref": "#/definitions/FeeExplanationNotApplicable"
+                }
+              ]
+            },
+            "files": {
+              "$ref": "#/definitions/PrototypeRequestedFiles"
+            },
+            "flowId": {
+              "$ref": "#/definitions/UUID"
+            },
+            "overrides": {
+              "$ref": "#/definitions/UserOverrides"
+            },
+            "url": {
+              "$ref": "#/definitions/URL"
+            }
+          },
+          "required": [
+            "flowId",
+            "url",
+            "files",
+            "fee"
+          ],
+          "type": "object"
+        },
+        "source": {
+          "const": "PlanX",
+          "type": "string"
+        },
+        "submittedAt": {
+          "$ref": "#/definitions/DateTime"
+        }
+      },
+      "required": [
+        "id",
+        "organisation",
+        "schema",
+        "service",
+        "source",
+        "submittedAt"
+      ],
+      "type": "object"
+    },
+    "PrototypeRequestedFiles": {
+      "additionalProperties": false,
+      "description": "File types requested by this service. Schema[\"files\"] will be a subset of this list based on the user's journey through the service",
+      "properties": {
+        "optional": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
+        },
+        "recommended": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
+        },
+        "required": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "required",
+        "recommended",
+        "optional"
       ],
       "type": "object"
     },
@@ -13324,36 +6255,21 @@
       },
       "type": "object"
     },
-    "RequestedFiles": {
-      "$id": "#RequestedFiles",
-      "additionalProperties": false,
-      "description": "File types requested by this service. Schema[\"files\"] will be a subset of this list based on the user's journey through the service",
-      "properties": {
-        "optional": {
-          "items": {
-            "$ref": "#/definitions/FileType"
-          },
-          "type": "array"
-        },
-        "recommended": {
-          "items": {
-            "$ref": "#/definitions/FileType"
-          },
-          "type": "array"
-        },
-        "required": {
-          "items": {
-            "$ref": "#/definitions/FileType"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "required",
-        "recommended",
-        "optional"
+    "Region": {
+      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
+      "enum": [
+        "North East",
+        "North West",
+        "Yorkshire and The Humber",
+        "East Midlands",
+        "West Midlands",
+        "East of England",
+        "London",
+        "South East",
+        "South West"
       ],
-      "type": "object"
+      "title": "#Region",
+      "type": "string"
     },
     "Response": {
       "additionalProperties": false,
@@ -13459,22 +6375,6 @@
       ],
       "type": "object"
     },
-    "UKRegion": {
-      "$id": "#UKRegion",
-      "description": "The UK region that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
-      "enum": [
-        "North East",
-        "North West",
-        "Yorkshire and The Humber",
-        "East Midlands",
-        "West Midlands",
-        "East of England",
-        "London",
-        "South East",
-        "South West"
-      ],
-      "type": "string"
-    },
     "URL": {
       "format": "uri",
       "pattern": "^https?://",
@@ -13504,7 +6404,6 @@
       "type": "object"
     },
     "UserAddress": {
-      "$id": "#UserAddress",
       "anyOf": [
         {
           "additionalProperties": false,
@@ -13523,10 +6422,10 @@
           "$ref": "#/definitions/UserAddressNotSameSite"
         }
       ],
-      "description": "Address information for the applicant"
+      "description": "Address information for the applicant",
+      "title": "#UserAddress"
     },
     "UserAddressNotSameSite": {
-      "$id": "#UserAddressNotSameSite",
       "additionalProperties": false,
       "description": "Address information for an applicant with contact information that differs from the property address",
       "properties": {
@@ -13559,6 +6458,128 @@
         "sameAsSiteAddress",
         "town"
       ],
+      "title": "#UserAddressNotSameSite",
+      "type": "object"
+    },
+    "UserOverrides": {
+      "additionalProperties": false,
+      "description": "Administrative data suggested by PlanX which the user overrode or changed",
+      "properties": {
+        "property": {
+          "additionalProperties": false,
+          "properties": {
+            "planning": {
+              "additionalProperties": false,
+              "properties": {
+                "designations": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "entities": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "text": {
+                                      "const": "Planning Data",
+                                      "type": "string"
+                                    },
+                                    "url": {
+                                      "$ref": "#/definitions/URL"
+                                    }
+                                  },
+                                  "required": [
+                                    "text",
+                                    "url"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "text": {
+                                      "const": "Ordnance Survey MasterMap Highways",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "text"
+                                  ],
+                                  "type": "object"
+                                }
+                              ]
+                            },
+                            "userReason": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "source",
+                            "userReason"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "sourceIntersects": {
+                        "const": true,
+                        "type": "boolean"
+                      },
+                      "userIntersects": {
+                        "const": false,
+                        "type": "boolean"
+                      },
+                      "value": {
+                        "$ref": "#/definitions/BasePlanningDesignation"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "sourceIntersects",
+                      "userIntersects",
+                      "entities"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "designations"
+              ],
+              "type": "object"
+            },
+            "type": {
+              "additionalProperties": false,
+              "properties": {
+                "sourceType": {
+                  "type": "string"
+                },
+                "userType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "sourceType",
+                "userType"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
       "type": "object"
     }
   },
@@ -13598,37 +6619,12 @@
     },
     "files": {
       "items": {
-        "additionalProperties": false,
-        "properties": {
-          "lastModified": {
-            "type": "number"
-          },
-          "name": {
-            "type": "string"
-          },
-          "size": {
-            "type": "number"
-          },
-          "type": {
-            "type": "string"
-          },
-          "webkitRelativePath": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "lastModified",
-          "name",
-          "size",
-          "type",
-          "webkitRelativePath"
-        ],
-        "type": "object"
+        "$ref": "#/definitions/File"
       },
       "type": "array"
     },
     "metadata": {
-      "$ref": "#/definitions/Metadata"
+      "$ref": "#/definitions/PrototypePlanXMetadata"
     },
     "responses": {
       "$ref": "#/definitions/Responses"

--- a/scripts/build-json-examples.ts
+++ b/scripts/build-json-examples.ts
@@ -33,14 +33,14 @@ const walkDirectory = async (dir: string) => {
       // Write file to mirrored directory, outside the /data folder where the TS examples are stored
       const jsonExampleFilePath = path.join(
         dir.replace('/data', ''),
-        `${path.basename(file, '.ts')}.json`
+        `${path.basename(file, '.ts')}.json`,
       );
       await convertTypeScriptObjectToJSON(filePath, jsonExampleFilePath);
     }
   }
 };
 
-(async () => {
+void (async () => {
   await walkDirectory('./examples');
   console.log('All example files converted to JSON');
 })();

--- a/scripts/build-schema.sh
+++ b/scripts/build-schema.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 echo "Running build-schema script..."
 
 # Use environment variable VERSION, defaulting to "@next" if not set

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -6,9 +6,11 @@ import addFormats from 'ajv-formats';
 import {Schema, Validator} from 'jsonschema';
 import {describe, expect, test} from 'vitest';
 import applicationSchema from '../schemas/application.json';
-import prototypeApplicationSchema from '../schemas/prototypeApplication.json';
+import preApplicationSchema from '../schemas/preApplication.json';
+// import prototypeApplicationSchema from '../schemas/prototypeApplication.json';
 import {Application} from '../types/schemas/application';
-import {PrototypeApplication} from '../types/schemas/prototypeApplication';
+import {PreApplication} from '../types/schemas/preApplication';
+// import {PrototypeApplication} from '../types/schemas/prototypeApplication';
 
 /**
  * Helper function to walk /examples directory and collect generated JSON files
@@ -43,6 +45,11 @@ const schemas = [
     schema: applicationSchema,
     examples: getJSONExamples<Application>('application'),
   },
+  {
+    name: 'PreApplication',
+    schema: preApplicationSchema,
+    examples: getJSONExamples<PreApplication>('preApplication'),
+  },
   // {
   //   name: 'PrototypeApplication',
   //   schema: prototypeApplicationSchema,
@@ -53,24 +60,24 @@ const schemas = [
 describe.each(schemas)('$name', ({schema, examples}) => {
   const validator = new Validator();
 
-  const _applicationTypeProperty =
-    '$data.application.type.description' || '$applicationType';
-
   describe("parsing using the 'jsonschema' library", () => {
-    describe.each(examples)('$data.application.type.description', example => {
-      test('accepts a valid example', async () => {
-        const result = validator.validate(example, schema as Schema);
+    describe.each<Application | PreApplication>(examples)(
+      '$data.application.type.description',
+      example => {
+        test('accepts a valid example', async () => {
+          const result = validator.validate(example, schema as Schema);
 
-        expect(result.errors).toHaveLength(0);
-      });
+          expect(result.errors).toHaveLength(0);
+        });
 
-      test('rejects an invalid example', () => {
-        const invalidExample = {foo: 'bar'};
-        const result = validator.validate(invalidExample, schema as Schema);
+        test('rejects an invalid example', () => {
+          const invalidExample = {foo: 'bar'};
+          const result = validator.validate(invalidExample, schema as Schema);
 
-        expect(result.errors).not.toHaveLength(0);
-      });
-    });
+          expect(result.errors).not.toHaveLength(0);
+        });
+      },
+    );
   });
 
   describe("parsing using the 'ajv' library", () => {
@@ -78,21 +85,24 @@ describe.each(schemas)('$name', ({schema, examples}) => {
     const ajv = addFormats(new Ajv({allowUnionTypes: true}));
     const validate = ajv.compile(schema);
 
-    describe.each(examples)('$data.application.type.description', example => {
-      test('accepts a valid example', async () => {
-        const isValid = validate(example);
+    describe.each<Application | PreApplication>(examples)(
+      '$data.application.type.description',
+      example => {
+        test('accepts a valid example', async () => {
+          const isValid = validate(example);
 
-        expect(validate.errors).toBeNull();
-        expect(isValid).toBe(true);
-      });
+          expect(validate.errors).toBeNull();
+          expect(isValid).toBe(true);
+        });
 
-      test('rejects an invalid example', () => {
-        const invalidExample = {foo: 'bar'};
-        const isValid = validate(invalidExample);
+        test('rejects an invalid example', () => {
+          const invalidExample = {foo: 'bar'};
+          const isValid = validate(invalidExample);
 
-        expect(validate.errors).not.toBeNull();
-        expect(isValid).toBe(false);
-      });
-    });
+          expect(validate.errors).not.toBeNull();
+          expect(isValid).toBe(false);
+        });
+      },
+    );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,14 @@
     "rootDir": ".",
     "outDir": "build",
     "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "include": [
     "examples/**/*.ts",
-    "schema/**/*.ts",
-    "scripts/**/*.ts"
+    "schemas/**/*.json",
+    "scripts/**/*.ts",
+    "tests/**/*.ts",
+    "types/**/*.ts"
   ]
 }

--- a/types/schemas/application/enums/PlanningConstraints.ts
+++ b/types/schemas/application/enums/PlanningConstraints.ts
@@ -1,4 +1,4 @@
-import {Entity} from '../../../shared/Constraints';
+import {Entity} from '../../../shared/Entity';
 
 /**
  * Values for `data.property.planning.designations`

--- a/types/schemas/preApplication/data/ApplicationData.ts
+++ b/types/schemas/preApplication/data/ApplicationData.ts
@@ -1,4 +1,5 @@
 import {Declaration} from '../../../shared/Declarations';
+import {PreApplicationType} from '../enums/PreApplicationTypes';
 import {Fee} from '../../../shared/Fees';
 
 /**
@@ -6,6 +7,7 @@ import {Fee} from '../../../shared/Fees';
  * @description Information about this planning pre-application
  */
 export interface PreApplicationData {
+  type: PreApplicationType;
   fee: Pick<Fee, 'payable' | 'reference'>;
   declaration: Declaration;
   information: {

--- a/types/schemas/preApplication/enums/PreApplicationTypes.ts
+++ b/types/schemas/preApplication/enums/PreApplicationTypes.ts
@@ -1,0 +1,27 @@
+/**
+ * Values of `data.application.type`
+ */
+export const PreApplicationTypes = {
+  preApp: 'Pre-application advice',
+  'preApp.householder': 'Pre-application advice - Householder',
+  'preApp.minor': 'Pre-application advice - Minor',
+  'preApp.major': 'Pre-application advice - Major',
+};
+
+export type PreApplicationTypeKeys = keyof typeof PreApplicationTypes;
+
+type GenericPreApplicationType<TKey extends PreApplicationTypeKeys> = {
+  value: TKey;
+  description: (typeof PreApplicationTypes)[TKey];
+};
+
+type PreApplicationTypeMap = {
+  [K in PreApplicationTypeKeys]: GenericPreApplicationType<K>;
+};
+
+/**
+ * @id #PreApplicationType
+ * @description Planning application types
+ */
+export type PreApplicationType =
+  PreApplicationTypeMap[keyof PreApplicationTypeMap];

--- a/types/schemas/prototypeApplication/Metadata.ts
+++ b/types/schemas/prototypeApplication/Metadata.ts
@@ -4,7 +4,7 @@ import {
   FeeExplanationNotApplicable,
 } from '../../shared/Metadata';
 import {URL, UUID} from '../../shared/utils';
-import {Entity} from './data/shared';
+import {Entity} from '../../shared/Entity';
 import {PrototypeFileType} from './enums/FileType';
 import {BasePlanningDesignation} from './enums/PlanningDesignation';
 

--- a/types/schemas/prototypeApplication/data/shared.ts
+++ b/types/schemas/prototypeApplication/data/shared.ts
@@ -1,21 +1,5 @@
-import {URL} from '../../../shared/utils';
 import {UKResidentialUnitType} from '../enums/ResidentialUnitType';
 import {UKTenureType} from '../enums/TenureType';
-
-export type Entity = {
-  name: string;
-  description?: string;
-  source: PlanningDataSource | OSRoadsSource;
-};
-
-type PlanningDataSource = {
-  text: 'Planning Data';
-  url: URL;
-};
-
-type OSRoadsSource = {
-  text: 'Ordnance Survey MasterMap Highways';
-};
 
 export type ResidentialUnits = {
   total: number;

--- a/types/schemas/prototypeApplication/enums/PlanningDesignation.ts
+++ b/types/schemas/prototypeApplication/enums/PlanningDesignation.ts
@@ -1,4 +1,4 @@
-import {Entity} from '../data/shared';
+import {Entity} from '../../../shared/Entity';
 /**
  * @description Article 4 Direction area
  */

--- a/types/shared/Constraints.ts
+++ b/types/shared/Constraints.ts
@@ -1,19 +1,4 @@
-import {URL} from './utils';
-
-type PlanningDataSource = {
-  text: 'Planning Data';
-  url: URL;
-};
-
-type OSRoadsSource = {
-  text: 'Ordnance Survey MasterMap Highways';
-};
-
-export type Entity = {
-  name: string;
-  description?: string;
-  source: PlanningDataSource | OSRoadsSource;
-};
+import {Entity} from './Entity';
 
 type BasePlanningConstraint = {
   value: string;

--- a/types/shared/Entity.ts
+++ b/types/shared/Entity.ts
@@ -1,0 +1,16 @@
+import {URL} from './utils';
+
+type PlanningDataSource = {
+  text: 'Planning Data';
+  url: URL;
+};
+
+type OSRoadsSource = {
+  text: 'Ordnance Survey MasterMap Highways';
+};
+
+export type Entity = {
+  name: string;
+  description?: string;
+  source: PlanningDataSource | OSRoadsSource;
+};


### PR DESCRIPTION
This mirrors the Application schema and reduces the need for branching when submitting to an endpoint that handles both pre-application and application requests.

In BOPS we're planning to create pre-applications as a type of planning application as the workflow closely mirrors that of an application and by having `applicationType` at the root it makes it difficult to handle cleanly. I've left `applicationType` in the root so that the change wouldn't break anyone depending on that.