### PR TITLE
fix: update `CommunityIinfrastructureLevy` types to include "not liable" path

### DIFF
--- a/schemas/application.json
+++ b/schemas/application.json
@@ -2766,25 +2766,47 @@
     },
     "CommunityInfrastructureLevy": {
       "$id": "#CommunityInfrastructureLevy",
-      "additionalProperties": false,
-      "description": "Details about the Community Infrastructure Levy planning charge, if applicable",
-      "properties": {
-        "result": {
-          "enum": [
-            "exempt.annexe",
-            "exempt.extension",
-            "exempt.selfBuild",
-            "liable",
-            "relief.charity",
-            "relief.socialHousing"
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "result": {
+              "enum": [
+                "exempt.annexe",
+                "exempt.extension",
+                "exempt.selfBuild",
+                "relief.charity",
+                "relief.socialHousing",
+                "liable"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
           ],
-          "type": "string"
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "declaration": {
+              "const": true,
+              "type": "boolean"
+            },
+            "result": {
+              "const": "notLiable",
+              "type": "string"
+            }
+          },
+          "required": [
+            "result",
+            "declaration"
+          ],
+          "type": "object"
         }
-      },
-      "required": [
-        "result"
       ],
-      "type": "object"
+      "description": "Details about the Community Infrastructure Levy planning charge, if applicable"
     },
     "ContactDetails": {
       "additionalProperties": false,

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -517,25 +517,48 @@
       "type": "object"
     },
     "CommunityInfrastructureLevy": {
-      "additionalProperties": false,
-      "description": "Details about the Community Infrastructure Levy planning charge, if applicable",
-      "properties": {
-        "result": {
-          "enum": [
-            "exempt.annexe",
-            "exempt.extension",
-            "exempt.selfBuild",
-            "liable",
-            "relief.charity",
-            "relief.socialHousing"
+      "$id": "#CommunityInfrastructureLevy",
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "result": {
+              "enum": [
+                "exempt.annexe",
+                "exempt.extension",
+                "exempt.selfBuild",
+                "relief.charity",
+                "relief.socialHousing",
+                "liable"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
           ],
-          "type": "string"
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "declaration": {
+              "const": true,
+              "type": "boolean"
+            },
+            "result": {
+              "const": "notLiable",
+              "type": "string"
+            }
+          },
+          "required": [
+            "result",
+            "declaration"
+          ],
+          "type": "object"
         }
-      },
-      "required": [
-        "result"
       ],
-      "type": "object"
+      "description": "Details about the Community Infrastructure Levy planning charge, if applicable"
     },
     "ContactDetails": {
       "additionalProperties": false,

--- a/types/schemas/application/data/ApplicationData.ts
+++ b/types/schemas/application/data/ApplicationData.ts
@@ -1,3 +1,4 @@
+import {CommunityInfrastructureLevy} from '../../../shared/CommunityInfrastructureLevy';
 import {Declaration} from '../../../shared/Declarations';
 import {Date} from '../../../shared/utils';
 import {ApplicationType} from '../enums/ApplicationTypes';
@@ -46,20 +47,6 @@ export interface PlanningApplication {
   reference: string;
   date: Date;
   localPlanningAuthority: string;
-}
-
-/**
- * @id #CommunityInfrastructureLevy
- * @description Details about the Community Infrastructure Levy planning charge, if applicable
- */
-export interface CommunityInfrastructureLevy {
-  result:
-    | 'exempt.annexe'
-    | 'exempt.extension'
-    | 'exempt.selfBuild'
-    | 'liable'
-    | 'relief.charity'
-    | 'relief.socialHousing';
 }
 
 export interface LeadDeveloper {

--- a/types/schemas/prototypeApplication/data/ApplicationData.ts
+++ b/types/schemas/prototypeApplication/data/ApplicationData.ts
@@ -2,6 +2,7 @@ import {PrimaryApplicationType} from '../enums/ApplicationType';
 import {Date} from '../../../shared/utils';
 import {Declaration} from '../../../shared/Declarations';
 import {Fee, FeeNotApplicable} from '../../../shared/Fees';
+import {CommunityInfrastructureLevy} from '../../../shared/CommunityInfrastructureLevy';
 
 /**
  * Base type for ApplicationData. Contains all shared properties across all application types
@@ -33,19 +34,6 @@ export interface PlanningApplication {
   reference: string;
   date: Date;
   localPlanningAuthority: string;
-}
-
-/**
- * @description Details about the Community Infrastructure Levy planning charge, if applicable
- */
-export interface CommunityInfrastructureLevy {
-  result:
-    | 'exempt.annexe'
-    | 'exempt.extension'
-    | 'exempt.selfBuild'
-    | 'liable'
-    | 'relief.charity'
-    | 'relief.socialHousing';
 }
 
 export interface LeadDeveloper {

--- a/types/shared/CommunityInfrastructureLevy.ts
+++ b/types/shared/CommunityInfrastructureLevy.ts
@@ -1,0 +1,21 @@
+/**
+ * @id #CommunityInfrastructureLevy
+ * @description Details about the Community Infrastructure Levy planning charge, if applicable
+ */
+export type CommunityInfrastructureLevy = LiableForCIL | NotLiableForCIL;
+
+type LiableForCIL = {
+  // Results are heirarchical (first check if project qualifies for full exemption from CIL, then CIL relief, else plain "liable")
+  result:
+    | 'exempt.annexe'
+    | 'exempt.extension'
+    | 'exempt.selfBuild'
+    | 'relief.charity'
+    | 'relief.socialHousing'
+    | 'liable';
+};
+
+type NotLiableForCIL = {
+  result: 'notLiable';
+  declaration: true;
+};


### PR DESCRIPTION
**Key changes:**
- Moves type definitions to `/shared`
- Unions `NotLiable` path, `Liable` definitions don't change

**Comes from:**
- Latest PlanX service development here: https://editor.planx.uk/opensystemslab/community-infrastructure-levy-copy (see final Filter & CIL flagset)
- Lambeth's CIL feedback/request for PP pilot: https://opensystemslab.slack.com/archives/C5Q59R3HB/p1733238460430359