### PR TITLE
fix: correct `pnpm build-schema` from main

### DIFF
--- a/schemas/application.json
+++ b/schemas/application.json
@@ -17884,7 +17884,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Ordance manufacturing & processing",
+              "const": "Ordnance manufacturing & processing",
               "type": "string"
             },
             "value": {
@@ -21668,7 +21668,7 @@
               "type": "string"
             },
             "value": {
-              "const": "commercial.utility.telecoms.exhange",
+              "const": "commercial.utility.telecoms.exchange",
               "type": "string"
             }
           },
@@ -26434,7 +26434,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Serviced accomodation",
+              "const": "Serviced accommodation",
               "type": "string"
             },
             "value": {

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -7086,7 +7086,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Ordance manufacturing & processing",
+              "const": "Ordnance manufacturing & processing",
               "type": "string"
             },
             "value": {
@@ -10870,7 +10870,7 @@
               "type": "string"
             },
             "value": {
-              "const": "commercial.utility.telecoms.exhange",
+              "const": "commercial.utility.telecoms.exchange",
               "type": "string"
             }
           },
@@ -15636,7 +15636,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Serviced accomodation",
+              "const": "Serviced accommodation",
               "type": "string"
             },
             "value": {


### PR DESCRIPTION
Realising that when I "accepted" the typo suggestions via the GitHub UI in #287, the `pnpm build-schema` pre-commit hook wouldn't have been triggered and I didn't manually make any further commits, so I failed to pick these typo corrections up in the actual built files ! Lesson learned !

![Screenshot from 2025-01-17 14-22-45](https://github.com/user-attachments/assets/2b6f2d81-68d6-4c18-b1a8-4eef59d285cf)

Will open a separate PR to correct files on the `/dist` branch for v0.7.2 as well.