### PR TITLE
chore: adjust optional preApp info for applications

### DIFF
--- a/schemas/application.json
+++ b/schemas/application.json
@@ -10266,10 +10266,7 @@
         }
       },
       "required": [
-        "reference",
-        "date",
-        "officer",
-        "summary"
+        "reference"
       ],
       "type": "object"
     },

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -6205,10 +6205,7 @@
         }
       },
       "required": [
-        "reference",
-        "date",
-        "officer",
-        "summary"
+        "reference"
       ],
       "type": "object"
     },

--- a/types/schemas/application/data/ApplicationData.ts
+++ b/types/schemas/application/data/ApplicationData.ts
@@ -34,9 +34,9 @@ export interface LondonApplicationData extends BaseApplicationData {
  */
 export interface PreApplication {
   reference: string;
-  date: Date;
-  officer: string;
-  summary: string;
+  date?: Date;
+  officer?: string;
+  summary?: string;
 }
 
 /**

--- a/types/schemas/prototypeApplication/data/ApplicationData.ts
+++ b/types/schemas/prototypeApplication/data/ApplicationData.ts
@@ -22,9 +22,9 @@ export interface EnglandApplicationData {
  */
 export interface PreApplication {
   reference: string;
-  date: Date;
-  officer: string;
-  summary: string;
+  date?: Date;
+  officer?: string;
+  summary?: string;
 }
 
 /**


### PR DESCRIPTION
New content only requires a reference (`application.preAppAdvice.reference`) if `application.preAppAdvice` is `true`.