### PR TITLE
chore: refactor more `/shared` type definitions

### DIFF
--- a/schemas/application.json
+++ b/schemas/application.json
@@ -5,7 +5,7 @@
   "definitions": {
     "Address": {
       "additionalProperties": false,
-      "description": "Address information for a person associated with this application not at the property address",
+      "description": "Address information for a person associated with this application not at the site address",
       "properties": {
         "country": {
           "type": "string"
@@ -31,6 +31,7 @@
         "town",
         "postcode"
       ],
+      "title": "Contact address",
       "type": "object"
     },
     "Agent": {
@@ -118,7 +119,7 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContact"
+          "$ref": "#/definitions/MaintenanceContacts"
         },
         "name": {
           "additionalProperties": false,
@@ -2194,7 +2195,7 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContact"
+          "$ref": "#/definitions/MaintenanceContacts"
         },
         "name": {
           "additionalProperties": false,
@@ -2765,7 +2766,6 @@
       "type": "object"
     },
     "CommunityInfrastructureLevy": {
-      "$id": "#CommunityInfrastructureLevy",
       "anyOf": [
         {
           "additionalProperties": false,
@@ -2806,7 +2806,8 @@
           "type": "object"
         }
       ],
-      "description": "Details about the Community Infrastructure Levy planning charge, if applicable"
+      "description": "Details about the Community Infrastructure Levy planning charge, if applicable",
+      "title": "Community Infrastructure Levy"
     },
     "ContactDetails": {
       "additionalProperties": false,
@@ -2864,7 +2865,7 @@
         "email",
         "phone"
       ],
-      "title": "#ContactDetails",
+      "title": "Contact details",
       "type": "object"
     },
     "Date": {
@@ -2911,7 +2912,7 @@
         "accurate",
         "connection"
       ],
-      "title": "#Declaration",
+      "title": "Declaration",
       "type": "object"
     },
     "DesignAndAccessStatement": {
@@ -3124,6 +3125,130 @@
       ],
       "type": "object"
     },
+    "ExistingLondonParking": {
+      "additionalProperties": false,
+      "description": "Existing parking spaces on the site per the Greater London Authority specification",
+      "properties": {
+        "buses": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "carClub": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "cars": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "cycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "disabled": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "motorcycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "offStreet": {
+          "additionalProperties": false,
+          "properties": {
+            "residential": {
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "count"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "residential"
+          ],
+          "type": "object"
+        },
+        "other": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "vans": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "Feature<Geometry,GeoJsonProperties>": {
       "additionalProperties": false,
       "description": "A feature object which contains a geometry and associated properties. https://tools.ietf.org/html/rfc7946#section-3.2",
@@ -3333,7 +3458,7 @@
         "exemption",
         "reduction"
       ],
-      "title": "#Fee",
+      "title": "Fee",
       "type": "object"
     },
     "FeeExplanation": {
@@ -3493,7 +3618,7 @@
       "required": [
         "notApplicable"
       ],
-      "title": "#FeeNotApplicable",
+      "title": "Fee not applicable",
       "type": "object"
     },
     "File": {
@@ -6352,127 +6477,7 @@
           "type": "object"
         },
         "parking": {
-          "additionalProperties": false,
-          "properties": {
-            "buses": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "carClub": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "cars": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "cycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "disabled": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "motorcycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "offStreet": {
-              "additionalProperties": false,
-              "properties": {
-                "residential": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "residential"
-              ],
-              "type": "object"
-            },
-            "other": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "vans": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/ExistingLondonParking"
         },
         "planning": {
           "additionalProperties": false,
@@ -7062,164 +7067,8 @@
           "description": "Increasing the height of existing buildings"
         },
         "parking": {
-          "additionalProperties": false,
-          "description": "Proposed parking spaces",
-          "properties": {
-            "buses": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "carClub": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "cars": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "cycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "disabled": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "motorcycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "offStreet": {
-              "additionalProperties": false,
-              "properties": {
-                "residential": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    },
-                    "difference": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count",
-                    "difference"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "residential"
-              ],
-              "type": "object"
-            },
-            "other": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "vans": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/ProposedLondonParking",
+          "description": "Proposed parking spaces"
         },
         "projectType": {
           "items": {
@@ -7734,8 +7583,7 @@
       ],
       "type": "object"
     },
-    "MaintenanceContact": {
-      "$id": "#MaintenanceContact",
+    "MaintenanceContacts": {
       "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
       "items": {
         "additionalProperties": false,
@@ -7762,6 +7610,7 @@
         ],
         "type": "object"
       },
+      "title": "Maintenance contacts",
       "type": "array"
     },
     "Materials": {
@@ -8024,7 +7873,7 @@
         "x",
         "y"
       ],
-      "title": "#OSAddress",
+      "title": "OS site address",
       "type": "object"
     },
     "OpenSpaceDesignation": {
@@ -8638,7 +8487,6 @@
       "type": "object"
     },
     "PlanningApplication": {
-      "$id": "#PlanningApplication",
       "additionalProperties": false,
       "description": "Details of the planning application linked to this application, if applicable",
       "properties": {
@@ -8657,6 +8505,7 @@
         "date",
         "localPlanningAuthority"
       ],
+      "title": "Planning application",
       "type": "object"
     },
     "PlanningConstraint": {
@@ -8714,7 +8563,7 @@
         }
       ],
       "description": "Planning constraints that intersect with the proposed site",
-      "title": "#PlanningConstraint"
+      "title": "Planning constraint"
     },
     "PlanningDesignation": {
       "$id": "#PlanningDesignation",
@@ -10248,7 +10097,6 @@
       "type": "array"
     },
     "PreApplication": {
-      "$id": "#PreApplication",
       "additionalProperties": false,
       "description": "Details of the pre-application preceeding this application, if applicable",
       "properties": {
@@ -10268,6 +10116,7 @@
       "required": [
         "reference"
       ],
+      "title": "Pre-application",
       "type": "object"
     },
     "PreAssessment": {
@@ -26583,7 +26432,167 @@
         "x",
         "y"
       ],
-      "title": "#ProposedAddress",
+      "title": "Proposed site address",
+      "type": "object"
+    },
+    "ProposedLondonParking": {
+      "additionalProperties": false,
+      "description": "Proposed parking spaces and total change or difference in parking spaces per the Greater London Authority specification",
+      "properties": {
+        "buses": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "carClub": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "cars": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "cycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "disabled": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "motorcycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "offStreet": {
+          "additionalProperties": false,
+          "properties": {
+            "residential": {
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "type": "number"
+                },
+                "difference": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "count",
+                "difference"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "residential"
+          ],
+          "type": "object"
+        },
+        "other": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "vans": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        }
+      },
       "type": "object"
     },
     "ProtectedSpaceDesignation": {
@@ -26778,7 +26787,7 @@
       "type": "object"
     },
     "Region": {
-      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
+      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where 'London' is a proxy for the Greater London Authority (GLA) area",
       "enum": [
         "North East",
         "North West",
@@ -26790,7 +26799,7 @@
         "South East",
         "South West"
       ],
-      "title": "#Region",
+      "title": "Region",
       "type": "string"
     },
     "RequestedFiles": {
@@ -27503,7 +27512,7 @@
         }
       ],
       "description": "Contact information for the site visit",
-      "title": "#SiteContact"
+      "title": "Site contact"
     },
     "SiteContactOther": {
       "additionalProperties": false,
@@ -27529,7 +27538,6 @@
         "email",
         "phone"
       ],
-      "title": "#SiteContactOther",
       "type": "object"
     },
     "UKProperty": {
@@ -27968,11 +27976,11 @@
         }
       ],
       "description": "Address information for the applicant",
-      "title": "#UserAddress"
+      "title": "User address"
     },
     "UserAddressNotSameSite": {
       "additionalProperties": false,
-      "description": "Address information for an applicant with contact information that differs from the property address",
+      "description": "Address information for an applicant with contact information that differs from the site address",
       "properties": {
         "country": {
           "type": "string"
@@ -28003,7 +28011,6 @@
         "sameAsSiteAddress",
         "town"
       ],
-      "title": "#UserAddressNotSameSite",
       "type": "object"
     }
   },

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -5,7 +5,7 @@
   "definitions": {
     "Address": {
       "additionalProperties": false,
-      "description": "Address information for a person associated with this application not at the property address",
+      "description": "Address information for a person associated with this application not at the site address",
       "properties": {
         "country": {
           "type": "string"
@@ -31,6 +31,7 @@
         "town",
         "postcode"
       ],
+      "title": "Contact address",
       "type": "object"
     },
     "Agent": {
@@ -118,7 +119,7 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContact"
+          "$ref": "#/definitions/MaintenanceContacts"
         },
         "name": {
           "additionalProperties": false,
@@ -379,7 +380,7 @@
         "email",
         "phone"
       ],
-      "title": "#ContactDetails",
+      "title": "Contact details",
       "type": "object"
     },
     "Date": {
@@ -426,7 +427,7 @@
         "accurate",
         "connection"
       ],
-      "title": "#Declaration",
+      "title": "Declaration",
       "type": "object"
     },
     "Email": {
@@ -2656,8 +2657,7 @@
       ],
       "type": "object"
     },
-    "MaintenanceContact": {
-      "$id": "#MaintenanceContact",
+    "MaintenanceContacts": {
       "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
       "items": {
         "additionalProperties": false,
@@ -2684,6 +2684,7 @@
         ],
         "type": "object"
       },
+      "title": "Maintenance contacts",
       "type": "array"
     },
     "MultiLineString": {
@@ -2862,7 +2863,7 @@
         "x",
         "y"
       ],
-      "title": "#OSAddress",
+      "title": "OS site address",
       "type": "object"
     },
     "Owners": {
@@ -15778,7 +15779,7 @@
         "x",
         "y"
       ],
-      "title": "#ProposedAddress",
+      "title": "Proposed site address",
       "type": "object"
     },
     "QuestionAndResponses": {
@@ -15841,7 +15842,7 @@
       "type": "object"
     },
     "Region": {
-      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
+      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where 'London' is a proxy for the Greater London Authority (GLA) area",
       "enum": [
         "North East",
         "North West",
@@ -15853,7 +15854,7 @@
         "South East",
         "South West"
       ],
-      "title": "#Region",
+      "title": "Region",
       "type": "string"
     },
     "RequestedFiles": {
@@ -15962,7 +15963,7 @@
         }
       ],
       "description": "Contact information for the site visit",
-      "title": "#SiteContact"
+      "title": "Site contact"
     },
     "SiteContactOther": {
       "additionalProperties": false,
@@ -15988,7 +15989,6 @@
         "email",
         "phone"
       ],
-      "title": "#SiteContactOther",
       "type": "object"
     },
     "URL": {
@@ -16039,11 +16039,11 @@
         }
       ],
       "description": "Address information for the applicant",
-      "title": "#UserAddress"
+      "title": "User address"
     },
     "UserAddressNotSameSite": {
       "additionalProperties": false,
-      "description": "Address information for an applicant with contact information that differs from the property address",
+      "description": "Address information for an applicant with contact information that differs from the site address",
       "properties": {
         "country": {
           "type": "string"
@@ -16074,7 +16074,6 @@
         "sameAsSiteAddress",
         "town"
       ],
-      "title": "#UserAddressNotSameSite",
       "type": "object"
     }
   },

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -21,7 +21,7 @@
   "definitions": {
     "Address": {
       "additionalProperties": false,
-      "description": "Address information for a person associated with this application not at the property address",
+      "description": "Address information for a person associated with this application not at the site address",
       "properties": {
         "country": {
           "type": "string"
@@ -47,6 +47,7 @@
         "town",
         "postcode"
       ],
+      "title": "Contact address",
       "type": "object"
     },
     "Agent": {
@@ -517,7 +518,6 @@
       "type": "object"
     },
     "CommunityInfrastructureLevy": {
-      "$id": "#CommunityInfrastructureLevy",
       "anyOf": [
         {
           "additionalProperties": false,
@@ -558,7 +558,8 @@
           "type": "object"
         }
       ],
-      "description": "Details about the Community Infrastructure Levy planning charge, if applicable"
+      "description": "Details about the Community Infrastructure Levy planning charge, if applicable",
+      "title": "Community Infrastructure Levy"
     },
     "ContactDetails": {
       "additionalProperties": false,
@@ -616,7 +617,7 @@
         "email",
         "phone"
       ],
-      "title": "#ContactDetails",
+      "title": "Contact details",
       "type": "object"
     },
     "Date": {
@@ -663,7 +664,7 @@
         "accurate",
         "connection"
       ],
-      "title": "#Declaration",
+      "title": "Declaration",
       "type": "object"
     },
     "DevelopmentType": {
@@ -1175,6 +1176,130 @@
       ],
       "type": "object"
     },
+    "ExistingLondonParking": {
+      "additionalProperties": false,
+      "description": "Existing parking spaces on the site per the Greater London Authority specification",
+      "properties": {
+        "buses": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "carClub": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "cars": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "cycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "disabled": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "motorcycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "offStreet": {
+          "additionalProperties": false,
+          "properties": {
+            "residential": {
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "count"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "residential"
+          ],
+          "type": "object"
+        },
+        "other": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        },
+        "vans": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
     "Feature<Geometry,GeoJsonProperties>": {
       "additionalProperties": false,
       "description": "A feature object which contains a geometry and associated properties. https://tools.ietf.org/html/rfc7946#section-3.2",
@@ -1384,7 +1509,7 @@
         "exemption",
         "reduction"
       ],
-      "title": "#Fee",
+      "title": "Fee",
       "type": "object"
     },
     "FeeCarryingApplicationData": {
@@ -1599,7 +1724,7 @@
       "required": [
         "notApplicable"
       ],
-      "title": "#FeeNotApplicable",
+      "title": "Fee not applicable",
       "type": "object"
     },
     "File": {
@@ -2821,127 +2946,7 @@
           "type": "array"
         },
         "parking": {
-          "additionalProperties": false,
-          "properties": {
-            "buses": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "carClub": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "cars": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "cycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "disabled": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "motorcycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "offStreet": {
-              "additionalProperties": false,
-              "properties": {
-                "residential": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "residential"
-              ],
-              "type": "object"
-            },
-            "other": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            },
-            "vans": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count"
-              ],
-              "type": "object"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/ExistingLondonParking"
         },
         "planning": {
           "additionalProperties": false,
@@ -3451,164 +3456,7 @@
           "description": "Increasing the height of existing buildings"
         },
         "parking": {
-          "additionalProperties": false,
-          "description": "Proposed parking spaces",
-          "properties": {
-            "buses": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "carClub": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "cars": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "cycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "disabled": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "motorcycles": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "offStreet": {
-              "additionalProperties": false,
-              "properties": {
-                "residential": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    },
-                    "difference": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count",
-                    "difference"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "residential"
-              ],
-              "type": "object"
-            },
-            "other": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            },
-            "vans": {
-              "additionalProperties": false,
-              "properties": {
-                "count": {
-                  "type": "number"
-                },
-                "difference": {
-                  "type": "number"
-                }
-              },
-              "required": [
-                "count",
-                "difference"
-              ],
-              "type": "object"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/ProposedLondonParking"
         },
         "projectType": {
           "items": {
@@ -4124,6 +3972,7 @@
       "type": "object"
     },
     "MaintenanceContacts": {
+      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -4149,6 +3998,7 @@
         ],
         "type": "object"
       },
+      "title": "Maintenance contacts",
       "type": "array"
     },
     "Materials": {
@@ -4453,7 +4303,7 @@
         "x",
         "y"
       ],
-      "title": "#OSAddress",
+      "title": "OS site address",
       "type": "object"
     },
     "OpenSpaceDesignation": {
@@ -5782,127 +5632,7 @@
               "$ref": "#/definitions/Materials"
             },
             "parking": {
-              "additionalProperties": false,
-              "properties": {
-                "buses": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                },
-                "carClub": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                },
-                "cars": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                },
-                "cycles": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                },
-                "disabled": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                },
-                "motorcycles": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                },
-                "offStreet": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "residential": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "count": {
-                          "type": "number"
-                        }
-                      },
-                      "required": [
-                        "count"
-                      ],
-                      "type": "object"
-                    }
-                  },
-                  "required": [
-                    "residential"
-                  ],
-                  "type": "object"
-                },
-                "other": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                },
-                "vans": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "count"
-                  ],
-                  "type": "object"
-                }
-              },
-              "type": "object"
+              "$ref": "#/definitions/ExistingLondonParking"
             },
             "planning": {
               "additionalProperties": false,
@@ -6029,6 +5759,7 @@
         "date",
         "localPlanningAuthority"
       ],
+      "title": "Planning application",
       "type": "object"
     },
     "PlanningConstraint": {
@@ -6207,6 +5938,7 @@
       "required": [
         "reference"
       ],
+      "title": "Pre-application",
       "type": "object"
     },
     "PreAssessment": {
@@ -10118,7 +9850,167 @@
         "x",
         "y"
       ],
-      "title": "#ProposedAddress",
+      "title": "Proposed site address",
+      "type": "object"
+    },
+    "ProposedLondonParking": {
+      "additionalProperties": false,
+      "description": "Proposed parking spaces and total change or difference in parking spaces per the Greater London Authority specification",
+      "properties": {
+        "buses": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "carClub": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "cars": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "cycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "disabled": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "motorcycles": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "offStreet": {
+          "additionalProperties": false,
+          "properties": {
+            "residential": {
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "type": "number"
+                },
+                "difference": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "count",
+                "difference"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "residential"
+          ],
+          "type": "object"
+        },
+        "other": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        },
+        "vans": {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "difference": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "count",
+            "difference"
+          ],
+          "type": "object"
+        }
+      },
       "type": "object"
     },
     "ProtectedSpaceDesignation": {
@@ -10880,7 +10772,7 @@
       "type": "object"
     },
     "Region": {
-      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
+      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where 'London' is a proxy for the Greater London Authority (GLA) area",
       "enum": [
         "North East",
         "North West",
@@ -10892,7 +10784,7 @@
         "South East",
         "South West"
       ],
-      "title": "#Region",
+      "title": "Region",
       "type": "string"
     },
     "ResidentialUnits": {
@@ -10992,7 +10884,12 @@
           "additionalProperties": false,
           "properties": {
             "role": {
-              "$ref": "#/definitions/UserRoles"
+              "enum": [
+                "applicant",
+                "agent",
+                "proxy"
+              ],
+              "type": "string"
             }
           },
           "required": [
@@ -11003,10 +10900,13 @@
         {
           "$ref": "#/definitions/SiteContactOther"
         }
-      ]
+      ],
+      "description": "Contact information for the site visit",
+      "title": "Site contact"
     },
     "SiteContactOther": {
       "additionalProperties": false,
+      "description": "Contact information for the site visit when the SiteContact's role is 'other'",
       "properties": {
         "email": {
           "type": "string"
@@ -11131,11 +11031,11 @@
         }
       ],
       "description": "Address information for the applicant",
-      "title": "#UserAddress"
+      "title": "User address"
     },
     "UserAddressNotSameSite": {
       "additionalProperties": false,
-      "description": "Address information for an applicant with contact information that differs from the property address",
+      "description": "Address information for an applicant with contact information that differs from the site address",
       "properties": {
         "country": {
           "type": "string"
@@ -11166,7 +11066,6 @@
         "sameAsSiteAddress",
         "town"
       ],
-      "title": "#UserAddressNotSameSite",
       "type": "object"
     },
     "UserBase": {

--- a/types/schemas/application/data/Applicant.ts
+++ b/types/schemas/application/data/Applicant.ts
@@ -1,5 +1,6 @@
 import {Address, UserAddress} from '../../../shared/Addresses';
 import {ContactDetails} from '../../../shared/Contacts';
+import {MaintenanceContacts} from '../../../shared/MaintenanceContact';
 import {Ownership} from '../../../shared/Ownership';
 import {SiteContact} from '../../../shared/SiteContact';
 
@@ -18,7 +19,7 @@ export type BaseApplicant = ContactDetails & {
   address: UserAddress;
   ownership?: Ownership;
   siteContact: SiteContact;
-  maintenanceContact?: MaintenanceContact;
+  maintenanceContact?: MaintenanceContacts;
 };
 
 /**
@@ -28,16 +29,3 @@ export type BaseApplicant = ContactDetails & {
 export interface Agent extends BaseApplicant {
   agent: ContactDetails & {address: Address};
 }
-
-/**
- * @id #MaintenanceContact
- * @description Contact information for the person(s) responsible for maintenance while the works are carried out
- */
-export type MaintenanceContact = {
-  when:
-    | 'duringConstruction'
-    | 'afterConstruction'
-    | 'duringAndAfterConstruction';
-  address: Address;
-  contact: ContactDetails;
-}[];

--- a/types/schemas/application/data/ApplicationData.ts
+++ b/types/schemas/application/data/ApplicationData.ts
@@ -1,8 +1,11 @@
 import {CommunityInfrastructureLevy} from '../../../shared/CommunityInfrastructureLevy';
 import {Declaration} from '../../../shared/Declarations';
-import {Date} from '../../../shared/utils';
-import {ApplicationType} from '../enums/ApplicationTypes';
 import {Fee, FeeNotApplicable} from '../../../shared/Fees';
+import {
+  PlanningApplication,
+  PreApplication,
+} from '../../../shared/LinkedApplications';
+import {ApplicationType} from '../enums/ApplicationTypes';
 
 /**
  * @id #ApplicationData
@@ -26,27 +29,6 @@ export interface BaseApplicationData {
 export interface LondonApplicationData extends BaseApplicationData {
   vacantBuildingCredit?: boolean;
   leadDeveloper?: LeadDeveloper;
-}
-
-/**
- * @id #PreApplication
- * @description Details of the pre-application preceeding this application, if applicable
- */
-export interface PreApplication {
-  reference: string;
-  date?: Date;
-  officer?: string;
-  summary?: string;
-}
-
-/**
- * @id #PlanningApplication
- * @description Details of the planning application linked to this application, if applicable
- */
-export interface PlanningApplication {
-  reference: string;
-  date: Date;
-  localPlanningAuthority: string;
 }
 
 export interface LeadDeveloper {

--- a/types/schemas/application/data/Property.ts
+++ b/types/schemas/application/data/Property.ts
@@ -1,6 +1,7 @@
 import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
 import {PlanningConstraint} from '../../../shared/Constraints';
 import {Materials} from '../../../shared/Materials';
+import {ExistingLondonParking} from '../../../shared/Parking';
 import {Region} from '../../../shared/Regions';
 import {Date, URL} from '../../../shared/utils';
 import {PlanningDesignation} from '../enums/PlanningConstraints';
@@ -113,17 +114,5 @@ export interface LondonProperty extends UKProperty {
   occupation?: {
     status: 'occupied' | 'partVacant' | 'vacant';
   };
-  parking?: {
-    cars?: ExistingCount;
-    vans?: ExistingCount;
-    motorcycles?: ExistingCount;
-    cycles?: ExistingCount;
-    buses?: ExistingCount;
-    disabled?: ExistingCount;
-    carClub?: ExistingCount;
-    offStreet?: {residential: ExistingCount};
-    other?: ExistingCount;
-  };
+  parking?: ExistingLondonParking;
 }
-
-type ExistingCount = {count: number};

--- a/types/schemas/application/data/Proposal.ts
+++ b/types/schemas/application/data/Proposal.ts
@@ -10,6 +10,7 @@ import {GLAResidentialUnitType} from '../enums/ResidentialUnitTypes';
 import {GLATenureType} from '../enums/TenureTypes';
 import {Area, Date} from '../../../shared/utils';
 import {ResidentialUnits} from './shared';
+import {ProposedLondonParking} from '../../../shared/Parking';
 
 /**
  * @id #Proposal
@@ -142,17 +143,7 @@ export interface LondonProposal extends Omit<BaseProposal, 'units'> {
   /**
    * @description Proposed parking spaces
    */
-  parking?: {
-    cars?: ProposedCount;
-    vans?: ProposedCount;
-    motorcycles?: ProposedCount;
-    cycles?: ProposedCount;
-    buses?: ProposedCount;
-    disabled?: ProposedCount;
-    carClub?: ProposedCount;
-    offStreet?: {residential: ProposedCount};
-    other?: ProposedCount;
-  };
+  parking?: ProposedLondonParking;
   /**
    * @description Creating new buildings
    */
@@ -260,11 +251,6 @@ export interface LondonProposal extends Omit<BaseProposal, 'units'> {
     };
   };
 }
-
-type ProposedCount = {
-  count: number;
-  difference: number;
-};
 
 /**
  * @id #NewBuildingsOrStoreys

--- a/types/schemas/prototypeApplication/data/Applicant.ts
+++ b/types/schemas/prototypeApplication/data/Applicant.ts
@@ -1,14 +1,15 @@
 import {Address, UserAddress} from '../../../shared/Addresses';
 import {ContactDetails} from '../../../shared/Contacts';
+import {MaintenanceContacts} from '../../../shared/MaintenanceContact';
 import {
   OwnersInterest,
   OwnersNoNoticeGiven,
   OwnersNoticeDate,
   OwnersNoticeGiven,
 } from '../../../shared/Ownership';
+import {SiteContact} from '../../../shared/SiteContact';
 import {Date} from '../../../shared/utils';
 import {PrimaryApplicationType} from '../enums/ApplicationType';
-import {UserRoles} from './User';
 
 export type ApplicantBase = BaseApplicant | Agent;
 
@@ -34,24 +35,6 @@ export interface Agent extends BaseApplicant {
   agent: ContactDetails & {address: Address};
 }
 
-export type SiteContact = {role: UserRoles} | SiteContactOther;
-
-export interface SiteContactOther {
-  role: 'other';
-  name: string;
-  email: string;
-  phone: string;
-}
-
-export type MaintenanceContacts = {
-  when:
-    | 'duringConstruction'
-    | 'afterConstruction'
-    | 'duringAndAfterConstruction';
-  address: Address;
-  contact: ContactDetails;
-}[];
-
 export type LDCApplicant = ApplicantBase & {
   /**
    * @description Information about the property owners, if different than the applicant
@@ -59,7 +42,7 @@ export type LDCApplicant = ApplicantBase & {
   ownership:
     | {interest: Extract<OwnersInterest, 'owner'>}
     | {
-        interest: OwnersInterest; // `Exclude<OwnershipInterest, "owner">` ? But I think you can be co owner & report other owners?
+        interest: OwnersInterest; // `Exclude<OwnershipInterest, "owner">` ? But I think you can be co-owner & report other owners?
         owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];
       };
 };

--- a/types/schemas/prototypeApplication/data/ApplicationData.ts
+++ b/types/schemas/prototypeApplication/data/ApplicationData.ts
@@ -1,39 +1,23 @@
 import {PrimaryApplicationType} from '../enums/ApplicationType';
-import {Date} from '../../../shared/utils';
 import {Declaration} from '../../../shared/Declarations';
 import {Fee, FeeNotApplicable} from '../../../shared/Fees';
 import {CommunityInfrastructureLevy} from '../../../shared/CommunityInfrastructureLevy';
+import {
+  PlanningApplication,
+  PreApplication,
+} from '../../../shared/LinkedApplications';
 
-/**
- * Base type for ApplicationData. Contains all shared properties across all application types
- */
 export type ApplicationDataBase =
   | EnglandApplicationData
   | LondonApplicationData;
 
+/**
+ * @description Application details for project sites anywhere in England
+ */
 export interface EnglandApplicationData {
   declaration: Declaration;
   preApp?: PreApplication;
   planningApp?: PlanningApplication;
-}
-
-/**
- * @description Details of the pre-application preceeding this application, if applicable
- */
-export interface PreApplication {
-  reference: string;
-  date?: Date;
-  officer?: string;
-  summary?: string;
-}
-
-/**
- * @description Details of the planning application linked to this application, if applicable
- */
-export interface PlanningApplication {
-  reference: string;
-  date: Date;
-  localPlanningAuthority: string;
 }
 
 export interface LeadDeveloper {

--- a/types/schemas/prototypeApplication/data/Property.ts
+++ b/types/schemas/prototypeApplication/data/Property.ts
@@ -69,8 +69,6 @@ export interface LondonProperty extends EnglandProperty {
   parking?: ExistingLondonParking;
 }
 
-type ExistingCount = {count: number};
-
 export type PPProperty = PropertyBase & {
   materials?: Materials;
   use?: {

--- a/types/schemas/prototypeApplication/data/Property.ts
+++ b/types/schemas/prototypeApplication/data/Property.ts
@@ -9,6 +9,7 @@ import {
   PlanningDesignation,
 } from '../enums/PlanningDesignation';
 import {PropertyType} from '../enums/PropertyTypes';
+import {ExistingLondonParking} from '../../../shared/Parking';
 
 export type PropertyBase = EnglandProperty | LondonProperty;
 
@@ -65,17 +66,7 @@ export interface LondonProperty extends EnglandProperty {
       | 'No';
     number?: string;
   };
-  parking?: {
-    cars?: ExistingCount;
-    vans?: ExistingCount;
-    motorcycles?: ExistingCount;
-    cycles?: ExistingCount;
-    buses?: ExistingCount;
-    disabled?: ExistingCount;
-    carClub?: ExistingCount;
-    offStreet?: {residential: ExistingCount};
-    other?: ExistingCount;
-  };
+  parking?: ExistingLondonParking;
 }
 
 type ExistingCount = {count: number};

--- a/types/schemas/prototypeApplication/data/Proposal.ts
+++ b/types/schemas/prototypeApplication/data/Proposal.ts
@@ -1,5 +1,6 @@
 import {GeoBoundary} from '../../../shared/Boundaries';
 import {Materials} from '../../../shared/Materials';
+import {ProposedLondonParking} from '../../../shared/Parking';
 import {Area, Date, Integer} from '../../../shared/utils';
 import {PrimaryApplicationType} from '../enums/ApplicationType';
 import {BuildingRegulation} from '../enums/BuildingRegulation';
@@ -138,20 +139,7 @@ export interface EnglandProposal {
  */
 export interface LondonProposal extends Omit<EnglandProposal, 'units'> {
   schemeName?: string;
-  /**
-   * @description Proposed parking spaces
-   */
-  parking?: {
-    cars?: ProposedCount;
-    vans?: ProposedCount;
-    motorcycles?: ProposedCount;
-    cycles?: ProposedCount;
-    buses?: ProposedCount;
-    disabled?: ProposedCount;
-    carClub?: ProposedCount;
-    offStreet?: {residential: ProposedCount};
-    other?: ProposedCount;
-  };
+  parking?: ProposedLondonParking;
   /**
    * @description Creating new buildings
    */
@@ -262,11 +250,6 @@ export interface LondonProposal extends Omit<EnglandProposal, 'units'> {
     };
   };
 }
-
-type ProposedCount = {
-  count: number;
-  difference: number;
-};
 
 /**
  * @description Details about creating new buildings or increasing the height of existing buildings

--- a/types/shared/Addresses.ts
+++ b/types/shared/Addresses.ts
@@ -25,7 +25,7 @@ export interface SiteAddress {
 }
 
 /**
- * @title #ProposedAddress
+ * @title Proposed site address
  * @description Address information for sites without a known Unique Property Reference Number (UPRN)
  */
 export interface ProposedAddress extends SiteAddress {
@@ -33,7 +33,7 @@ export interface ProposedAddress extends SiteAddress {
 }
 
 /**
- * @title #OSAddress
+ * @title OS site address
  * @description Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium LPI source
  */
 export interface OSAddress extends SiteAddress {
@@ -76,7 +76,8 @@ export interface OSAddress extends SiteAddress {
 }
 
 /**
- * @description Address information for a person associated with this application not at the property address
+ * @title Contact address
+ * @description Address information for a person associated with this application not at the site address
  */
 export interface Address {
   line1: string;
@@ -88,14 +89,13 @@ export interface Address {
 }
 
 /**
- * @title #UserAddress
+ * @title User address
  * @description Address information for the applicant
  */
 export type UserAddress = {sameAsSiteAddress: true} | UserAddressNotSameSite;
 
 /**
- * @title #UserAddressNotSameSite
- * @description Address information for an applicant with contact information that differs from the property address
+ * @description Address information for an applicant with contact information that differs from the site address
  */
 export interface UserAddressNotSameSite extends Address {
   sameAsSiteAddress: false;

--- a/types/shared/CommunityInfrastructureLevy.ts
+++ b/types/shared/CommunityInfrastructureLevy.ts
@@ -1,11 +1,11 @@
 /**
- * @id #CommunityInfrastructureLevy
+ * @title Community Infrastructure Levy
  * @description Details about the Community Infrastructure Levy planning charge, if applicable
  */
 export type CommunityInfrastructureLevy = LiableForCIL | NotLiableForCIL;
 
 type LiableForCIL = {
-  // Results are heirarchical (first check if project qualifies for full exemption from CIL, then CIL relief, else plain "liable")
+  // Result checks in PlanX are heirarchical (first check if project qualifies for full exemption from CIL, then CIL relief, else plain "liable")
   result:
     | 'exempt.annexe'
     | 'exempt.extension'

--- a/types/shared/Constraints.ts
+++ b/types/shared/Constraints.ts
@@ -36,7 +36,7 @@ type IntersectingPlanningConstraint = {
 } & BasePlanningConstraint;
 
 /**
- * @title #PlanningConstraint
+ * @title Planning constraint
  * @description Planning constraints that intersect with the proposed site
  */
 export type PlanningConstraint =

--- a/types/shared/Contacts.ts
+++ b/types/shared/Contacts.ts
@@ -1,7 +1,7 @@
 import {Email} from './utils';
 
 /**
- * @title #ContactDetails
+ * @title Contact details
  * @description Contact details for a person associated with this application
  */
 export type ContactDetails = {

--- a/types/shared/Declarations.ts
+++ b/types/shared/Declarations.ts
@@ -1,5 +1,5 @@
 /**
- * @title #Declaration
+ * @title Declaration
  * @description Declarations about the accuracy of this application and any personal connections to the receiving authority
  */
 export interface Declaration {

--- a/types/shared/Fees.ts
+++ b/types/shared/Fees.ts
@@ -1,5 +1,5 @@
 /**
- * @title #FeeNotApplicable
+ * @title Fee not applicable
  * @description An indicator that an application fee does not apply to this application type or journey
  */
 export interface FeeNotApplicable {
@@ -7,7 +7,7 @@ export interface FeeNotApplicable {
 }
 
 /**
- * @title #Fee
+ * @title Fee
  * @description The costs associated with this application
  */
 export interface Fee {

--- a/types/shared/LinkedApplications.ts
+++ b/types/shared/LinkedApplications.ts
@@ -1,0 +1,22 @@
+import {Date} from './utils';
+
+/**
+ * @title Pre-application
+ * @description Details of the pre-application preceeding this application, if applicable
+ */
+export interface PreApplication {
+  reference: string;
+  date?: Date;
+  officer?: string;
+  summary?: string;
+}
+
+/**
+ * @title Planning application
+ * @description Details of the planning application linked to this application, if applicable
+ */
+export interface PlanningApplication {
+  reference: string;
+  date: Date;
+  localPlanningAuthority: string;
+}

--- a/types/shared/MaintenanceContact.ts
+++ b/types/shared/MaintenanceContact.ts
@@ -1,0 +1,15 @@
+import {Address} from './Addresses';
+import {ContactDetails} from './Contacts';
+
+/**
+ * @title Maintenance contacts
+ * @description Contact information for the person(s) responsible for maintenance while the works are carried out
+ */
+export type MaintenanceContacts = {
+  when:
+    | 'duringConstruction'
+    | 'afterConstruction'
+    | 'duringAndAfterConstruction';
+  address: Address;
+  contact: ContactDetails;
+}[];

--- a/types/shared/Parking.ts
+++ b/types/shared/Parking.ts
@@ -1,0 +1,36 @@
+type ProposedCount = {
+  count: number;
+  difference: number;
+};
+
+type ExistingCount = {count: number};
+
+/**
+ * @description Proposed parking spaces and total change or difference in parking spaces per the Greater London Authority specification
+ */
+export type ProposedLondonParking = {
+  cars?: ProposedCount;
+  vans?: ProposedCount;
+  motorcycles?: ProposedCount;
+  cycles?: ProposedCount;
+  buses?: ProposedCount;
+  disabled?: ProposedCount;
+  carClub?: ProposedCount;
+  offStreet?: {residential: ProposedCount};
+  other?: ProposedCount;
+};
+
+/**
+ * @description Existing parking spaces on the site per the Greater London Authority specification
+ */
+export type ExistingLondonParking = {
+  cars?: ExistingCount;
+  vans?: ExistingCount;
+  motorcycles?: ExistingCount;
+  cycles?: ExistingCount;
+  buses?: ExistingCount;
+  disabled?: ExistingCount;
+  carClub?: ExistingCount;
+  offStreet?: {residential: ExistingCount};
+  other?: ExistingCount;
+};

--- a/types/shared/Regions.ts
+++ b/types/shared/Regions.ts
@@ -1,6 +1,6 @@
 /**
- * @title #Region
- * @description The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area
+ * @title Region
+ * @description The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where 'London' is a proxy for the Greater London Authority (GLA) area
  */
 export type Region =
   | 'North East'

--- a/types/shared/SiteContact.ts
+++ b/types/shared/SiteContact.ts
@@ -1,13 +1,12 @@
 import {User} from './User';
 
 /**
- * @title #SiteContact
+ * @title Site contact
  * @description Contact information for the site visit
  */
 export type SiteContact = {role: User['role']} | SiteContactOther;
 
 /**
- * @title #SiteContactOther
  * @description Contact information for the site visit when the SiteContact's role is 'other'
  */
 export interface SiteContactOther {


### PR DESCRIPTION
Only code re-organisations here, no functional changes! All examples still validate and tests pass. 

**Key changes:**
- Add `/shared` types for `Parking`, `MaintenanceContacts`, and `LinkedApplications`
- Update a number of `@title` annotations to drop `#` this is not required and a remnant of copying past `@id` (which do require `#`) to now `@title`