### PR TITLE
chore: tweak `Ownership` definitions

### DIFF
--- a/examples/application/data/planningPermission/major.ts
+++ b/examples/application/data/planningPermission/major.ts
@@ -46,6 +46,7 @@ export const planningPermissionMajor: Application = {
               country: 'Greece',
               postcode: '212 00',
             },
+            interest: 'Owner',
             noticeGiven: true,
           },
         ],

--- a/examples/application/data/planningPermission/major.ts
+++ b/examples/application/data/planningPermission/major.ts
@@ -46,8 +46,7 @@ export const planningPermissionMajor: Application = {
               country: 'Greece',
               postcode: '212 00',
             },
-            interest: 'Owner',
-            noticeGiven: true,
+            noticeDate: '2024-01-01',
           },
         ],
         declaration: {

--- a/examples/application/planningPermission/major.json
+++ b/examples/application/planningPermission/major.json
@@ -41,8 +41,7 @@
               "country": "Greece",
               "postcode": "212 00"
             },
-            "interest": "Owner",
-            "noticeGiven": true
+            "noticeDate": "2024-01-01"
           }
         ],
         "declaration": {

--- a/examples/application/planningPermission/major.json
+++ b/examples/application/planningPermission/major.json
@@ -41,6 +41,7 @@
               "country": "Greece",
               "postcode": "212 00"
             },
+            "interest": "Owner",
             "noticeGiven": true
           }
         ],

--- a/schemas/application.json
+++ b/schemas/application.json
@@ -8529,17 +8529,10 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/Address"
         },
         "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -8554,6 +8547,7 @@
       },
       "required": [
         "address",
+        "interest",
         "name",
         "noNoticeReason",
         "noticeGiven"
@@ -8564,17 +8558,7 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "$ref": "#/definitions/Address"
         },
         "name": {
           "type": "string"
@@ -8594,17 +8578,10 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/Address"
         },
         "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -8616,6 +8593,7 @@
       },
       "required": [
         "address",
+        "interest",
         "name",
         "noticeGiven"
       ],
@@ -8666,6 +8644,9 @@
               "type": "string"
             }
           ]
+        },
+        "interestDescription": {
+          "type": "string"
         },
         "noticeGiven": {
           "description": "Has requisite notice been given to all the known owners and agricultural tenants?",

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -2896,17 +2896,10 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/Address"
         },
         "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -2921,6 +2914,7 @@
       },
       "required": [
         "address",
+        "interest",
         "name",
         "noNoticeReason",
         "noticeGiven"
@@ -2931,17 +2925,7 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "$ref": "#/definitions/Address"
         },
         "name": {
           "type": "string"
@@ -2961,17 +2945,10 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/Address"
         },
         "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -2983,6 +2960,7 @@
       },
       "required": [
         "address",
+        "interest",
         "name",
         "noticeGiven"
       ],
@@ -3033,6 +3011,9 @@
               "type": "string"
             }
           ]
+        },
+        "interestDescription": {
+          "type": "string"
         },
         "noticeGiven": {
           "description": "Has requisite notice been given to all the known owners and agricultural tenants?",

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -3972,6 +3972,37 @@
                   "additionalProperties": false,
                   "properties": {
                     "interest": {
+                      "const": "other",
+                      "type": "string"
+                    },
+                    "interestDescription": {
+                      "type": "string"
+                    },
+                    "owners": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/OwnersNoticeGiven"
+                          },
+                          {
+                            "$ref": "#/definitions/OwnersNoNoticeGiven"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "interest",
+                    "interestDescription",
+                    "owners"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "interest": {
                       "$ref": "#/definitions/OwnersInterest"
                     },
                     "owners": {
@@ -4150,6 +4181,37 @@
                   },
                   "required": [
                     "interest"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "interest": {
+                      "const": "other",
+                      "type": "string"
+                    },
+                    "interestDescription": {
+                      "type": "string"
+                    },
+                    "owners": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/OwnersNoticeGiven"
+                          },
+                          {
+                            "$ref": "#/definitions/OwnersNoNoticeGiven"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "interest",
+                    "interestDescription",
+                    "owners"
                   ],
                   "type": "object"
                 },
@@ -6243,17 +6305,10 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/Address"
         },
         "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -6268,6 +6323,7 @@
       },
       "required": [
         "address",
+        "interest",
         "name",
         "noNoticeReason",
         "noticeGiven"
@@ -6278,17 +6334,7 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "$ref": "#/definitions/Address"
         },
         "name": {
           "type": "string"
@@ -6308,17 +6354,10 @@
       "additionalProperties": false,
       "properties": {
         "address": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Address"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/Address"
         },
         "interest": {
-          "$ref": "#/definitions/OwnersInterest"
+          "type": "string"
         },
         "name": {
           "type": "string"
@@ -6330,6 +6369,7 @@
       },
       "required": [
         "address",
+        "interest",
         "name",
         "noticeGiven"
       ],

--- a/types/schemas/prototypeApplication/data/Applicant.ts
+++ b/types/schemas/prototypeApplication/data/Applicant.ts
@@ -40,7 +40,12 @@ export type LDCApplicant = ApplicantBase & {
    * @description Information about the property owners, if different than the applicant
    */
   ownership:
-    | {interest: Extract<OwnersInterest, 'owner'>}
+    | {interest: Extract<OwnersInterest, 'owner'>} // sole owner does not report `owners`
+    | {
+        interest: Extract<OwnersInterest, 'other'>;
+        interestDescription: string; // "other" interest uniquely requires a free text description
+        owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];
+      }
     | {
         interest: OwnersInterest; // `Exclude<OwnershipInterest, "owner">` ? But I think you can be co-owner & report other owners?
         owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];

--- a/types/shared/Ownership.ts
+++ b/types/shared/Ownership.ts
@@ -9,6 +9,7 @@ export type OwnersInterest = 'owner' | 'lessee' | 'occupier' | 'other';
  */
 export interface Ownership {
   interest?: OwnersInterest | 'owner.sole' | 'owner.co';
+  interestDescription?: string;
   certificate?: 'a' | 'b' | 'c' | 'd';
   /**
    * @description Does the land have any agricultural tenants?
@@ -47,21 +48,24 @@ export type Owners = OwnersNoticeGiven | OwnersNoNoticeGiven | OwnersNoticeDate;
 
 export interface BaseOwners {
   name: string;
-  address: Address | string;
-  interest?: OwnersInterest;
+  address: Address;
 }
 
-// LDC requires `noticeGiven`, and `noNoticeReason` if false
-export interface OwnersNoticeGiven extends BaseOwners {
+// PP & LBC require `noticeDate` (PlanX List schema "Ownership Certificate Owners")
+export interface OwnersNoticeDate extends BaseOwners {
+  noticeDate: Date;
+}
+
+// LDC requires `noticeGiven`, and `noNoticeReason` if false (PlanX List schema "Interest in Land LDC")
+export interface OwnersInterestedInLand extends BaseOwners {
+  interest: string;
+}
+
+export interface OwnersNoticeGiven extends OwnersInterestedInLand {
   noticeGiven: true;
 }
 
-export interface OwnersNoNoticeGiven extends BaseOwners {
+export interface OwnersNoNoticeGiven extends OwnersInterestedInLand {
   noticeGiven: false;
   noNoticeReason: string;
-}
-
-// PP & LBC require `noticeDate`
-export interface OwnersNoticeDate extends BaseOwners {
-  noticeDate: Date;
 }


### PR DESCRIPTION
See context here https://opensystemslab.slack.com/archives/C089LL9LR5H/p1739544939178549

Brings schema definitions into sync with new "List" component schemas in PlanX https://github.com/theopensystemslab/planx-new/pull/4248