### PR TITLE
Add publishedAt to PostSubmissionFile

### DIFF
--- a/schemas/postSubmissionApplication.json
+++ b/schemas/postSubmissionApplication.json
@@ -12800,6 +12800,9 @@
             "mimeType": {
               "type": "string"
             },
+            "publishedAt": {
+              "$ref": "#/definitions/DateTime"
+            },
             "uploadedAt": {
               "$ref": "#/definitions/DateTime"
             }
@@ -12808,7 +12811,8 @@
             "byteSize",
             "mimeType",
             "createdAt",
-            "uploadedAt"
+            "uploadedAt",
+            "publishedAt"
           ],
           "type": "object"
         },

--- a/types/schemas/postSubmissionApplication/data/File.ts
+++ b/types/schemas/postSubmissionApplication/data/File.ts
@@ -10,15 +10,16 @@ export interface PostSubmissionFile {
   type?: FileType[];
   description?: string;
   url: string;
-  metadata: FileMetadata;
+  metadata: PostSubmissionFileMetadata;
 }
 
 /**
  * @description Metadata about the file
  */
-interface FileMetadata {
+interface PostSubmissionFileMetadata {
   byteSize: number;
   mimeType: string;
   createdAt: DateTime;
   uploadedAt: DateTime;
+  publishedAt: DateTime;
 }


### PR DESCRIPTION
I updated #318 with details about filtering and searching documents and realised we didn't have a `publishedAt` field in the `PostSubmissionFile` yet. 


I also renamed `FileMetadata` to `PostSubmissionFileMetadata` to avoid confusion with the existing `File` type.
