### PR TITLE
Differentiate between planning officer and council decision

### DIFF
--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-04-assessment-01-council-determined.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-04-assessment-01-council-determined.ts
@@ -35,9 +35,9 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-04-assessment-02-assessment-in-committee.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-04-assessment-02-assessment-in-committee.ts
@@ -35,7 +35,7 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilRecommendation: 'refused',
+        planningOfficerRecommendation: 'refused',
         committeeSentDate: formatDateToYYYYMMDD(
           realisticDates.assessment.committeeSentAt.toISOString(),
         ),

--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-04-assessment-03-committee-determined.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-04-assessment-03-committee-determined.ts
@@ -35,7 +35,7 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilRecommendation: 'refused',
+        planningOfficerRecommendation: 'refused',
         committeeSentDate: formatDateToYYYYMMDD(
           realisticDates.assessment.committeeSentAt.toISOString(),
         ),

--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-00-appeal-lodged.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-00-appeal-lodged.ts
@@ -35,9 +35,9 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-01-appeal-validated.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-01-appeal-validated.ts
@@ -35,9 +35,9 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-02-appeal-started.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-02-appeal-started.ts
@@ -35,9 +35,9 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-03-appeal-determined.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-03-appeal-determined.ts
@@ -35,9 +35,9 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-04-appeal-withdrawn.ts
+++ b/examples/postSubmissionApplication/data/lawfulDevelopmentCertificate/proposed-05-appeal-04-appeal-withdrawn.ts
@@ -35,9 +35,9 @@ export const lawfulDevelopmentCertificateProposedPostSubmission: PostSubmissionA
         isValid: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-04-assessment-01-council-determined.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-04-assessment-01-council-determined.ts
@@ -44,9 +44,9 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-04-assessment-02-assessment-in-committee.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-04-assessment-02-assessment-in-committee.ts
@@ -44,7 +44,7 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilRecommendation: 'refused',
+        planningOfficerRecommendation: 'refused',
         committeeSentDate: formatDateToYYYYMMDD(
           realisticDates.assessment.committeeSentAt.toISOString(),
         ),

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-04-assessment-03-committee-determined.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-04-assessment-03-committee-determined.ts
@@ -44,7 +44,7 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilRecommendation: 'refused',
+        planningOfficerRecommendation: 'refused',
         committeeSentDate: formatDateToYYYYMMDD(
           realisticDates.assessment.committeeSentAt.toISOString(),
         ),

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-00-appeal-lodged.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-00-appeal-lodged.ts
@@ -44,9 +44,9 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-01-appeal-validated.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-01-appeal-validated.ts
@@ -44,9 +44,9 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-02-appeal-started.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-02-appeal-started.ts
@@ -44,9 +44,9 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-03-appeal-determined.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-03-appeal-determined.ts
@@ -44,9 +44,9 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-04-appeal-withdrawn.ts
+++ b/examples/postSubmissionApplication/data/planningPermission/fullHouseholder-05-appeal-04-appeal-withdrawn.ts
@@ -44,9 +44,9 @@ export const planningPermissionFullHouseholderPostSubmission: PostSubmissionAppl
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         decisionNotice: {
           url: 'https://planningregister.org',

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-04-assessment-01-council-determined.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-04-assessment-01-council-determined.ts
@@ -45,9 +45,9 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         priorApprovalRequired: true,
         decisionNotice: {

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.ts
@@ -46,7 +46,7 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
       },
       assessment: {
         priorApprovalRequired: true,
-        councilRecommendation: 'refused',
+        planningOfficerRecommendation: 'refused',
         committeeSentDate: formatDateToYYYYMMDD(
           realisticDates.assessment.committeeSentAt.toISOString(),
         ),

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-04-assessment-03-committee-determined.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-04-assessment-03-committee-determined.ts
@@ -46,7 +46,7 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
       },
       assessment: {
         priorApprovalRequired: true,
-        councilRecommendation: 'refused',
+        planningOfficerRecommendation: 'refused',
         committeeSentDate: formatDateToYYYYMMDD(
           realisticDates.assessment.committeeSentAt.toISOString(),
         ),

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-00-appeal-lodged.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-00-appeal-lodged.ts
@@ -44,9 +44,9 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         priorApprovalRequired: true,
         decisionNotice: {

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-01-appeal-validated.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-01-appeal-validated.ts
@@ -44,9 +44,9 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         priorApprovalRequired: true,
         decisionNotice: {

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-02-appeal-started.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-02-appeal-started.ts
@@ -44,9 +44,9 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         priorApprovalRequired: true,
         decisionNotice: {

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-03-appeal-determined.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-03-appeal-determined.ts
@@ -44,9 +44,9 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         priorApprovalRequired: true,
         decisionNotice: {

--- a/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-04-appeal-withdrawn.ts
+++ b/examples/postSubmissionApplication/data/priorApproval/largerExtension-05-appeal-04-appeal-withdrawn.ts
@@ -44,9 +44,9 @@ export const priorApprovalLargerExtensionPostSubmission: PostSubmissionApplicati
         siteNotice: true,
       },
       assessment: {
-        councilDecision: 'granted',
-        councilDecisionDate: formatDateToYYYYMMDD(
-          realisticDates.assessment.councilDecisionAt.toISOString(),
+        planningOfficerDecision: 'granted',
+        planningOfficerDecisionDate: formatDateToYYYYMMDD(
+          realisticDates.assessment.planningOfficerDecisionAt.toISOString(),
         ),
         priorApprovalRequired: true,
         decisionNotice: {

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-01-council-determined.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-01-council-determined.json
@@ -18,8 +18,8 @@
       "isValid": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-02-assessment-in-committee.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-02-assessment-in-committee.json
@@ -18,7 +18,7 @@
       "isValid": true
     },
     "assessment": {
-      "councilRecommendation": "refused",
+      "planningOfficerRecommendation": "refused",
       "committeeSentDate": "2024-03-22"
     },
     "caseOfficer": {

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-03-committee-determined.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-03-committee-determined.json
@@ -18,7 +18,7 @@
       "isValid": true
     },
     "assessment": {
-      "councilRecommendation": "refused",
+      "planningOfficerRecommendation": "refused",
       "committeeSentDate": "2024-03-22",
       "committeeDecision": "granted",
       "committeeDecisionDate": "2024-04-01",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-00-appeal-lodged.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-00-appeal-lodged.json
@@ -18,8 +18,8 @@
       "isValid": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-01-appeal-validated.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-01-appeal-validated.json
@@ -18,8 +18,8 @@
       "isValid": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-02-appeal-started.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-02-appeal-started.json
@@ -18,8 +18,8 @@
       "isValid": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-03-appeal-determined.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-03-appeal-determined.json
@@ -18,8 +18,8 @@
       "isValid": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-04-appeal-withdrawn.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-04-appeal-withdrawn.json
@@ -18,8 +18,8 @@
       "isValid": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-01-council-determined.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-01-council-determined.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-02-assessment-in-committee.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-02-assessment-in-committee.json
@@ -23,7 +23,7 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilRecommendation": "refused",
+      "planningOfficerRecommendation": "refused",
       "committeeSentDate": "2024-03-22"
     },
     "caseOfficer": {

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-03-committee-determined.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-03-committee-determined.json
@@ -23,7 +23,7 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilRecommendation": "refused",
+      "planningOfficerRecommendation": "refused",
       "committeeSentDate": "2024-03-22",
       "committeeDecision": "granted",
       "committeeDecisionDate": "2024-04-01",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-00-appeal-lodged.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-00-appeal-lodged.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-01-appeal-validated.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-01-appeal-validated.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-02-appeal-started.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-02-appeal-started.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-03-appeal-determined.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-03-appeal-determined.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-04-appeal-withdrawn.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-04-appeal-withdrawn.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "decisionNotice": {
         "url": "https://planningregister.org"
       }

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-01-council-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-01-council-determined.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "priorApprovalRequired": true,
       "decisionNotice": {
         "url": "https://planningregister.org"

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.json
@@ -24,7 +24,7 @@
     },
     "assessment": {
       "priorApprovalRequired": true,
-      "councilRecommendation": "refused",
+      "planningOfficerRecommendation": "refused",
       "committeeSentDate": "2024-03-22"
     },
     "caseOfficer": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-03-committee-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-03-committee-determined.json
@@ -24,7 +24,7 @@
     },
     "assessment": {
       "priorApprovalRequired": true,
-      "councilRecommendation": "refused",
+      "planningOfficerRecommendation": "refused",
       "committeeSentDate": "2024-03-22",
       "committeeDecision": "granted",
       "committeeDecisionDate": "2024-04-01",

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-00-appeal-lodged.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-00-appeal-lodged.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "priorApprovalRequired": true,
       "decisionNotice": {
         "url": "https://planningregister.org"

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-01-appeal-validated.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-01-appeal-validated.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "priorApprovalRequired": true,
       "decisionNotice": {
         "url": "https://planningregister.org"

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-02-appeal-started.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-02-appeal-started.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "priorApprovalRequired": true,
       "decisionNotice": {
         "url": "https://planningregister.org"

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-03-appeal-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-03-appeal-determined.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "priorApprovalRequired": true,
       "decisionNotice": {
         "url": "https://planningregister.org"

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-04-appeal-withdrawn.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-04-appeal-withdrawn.json
@@ -23,8 +23,8 @@
       "siteNotice": true
     },
     "assessment": {
-      "councilDecision": "granted",
-      "councilDecisionDate": "2024-03-21",
+      "planningOfficerDecision": "granted",
+      "planningOfficerDecisionDate": "2024-03-21",
       "priorApprovalRequired": true,
       "decisionNotice": {
         "url": "https://planningregister.org"

--- a/schemas/postSubmissionApplication.json
+++ b/schemas/postSubmissionApplication.json
@@ -350,7 +350,7 @@
     },
     "AssessmentBase": {
       "additionalProperties": false,
-      "description": "'Granted', 'Refused', 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused';",
+      "description": "Council decision is planningOfficerDecision || committeeDecision Council decision date is planningOfficerDecisionDate || committeeDecisionDate",
       "properties": {
         "committeeDecision": {
           "$ref": "#/definitions/AssessmentDecision",
@@ -362,19 +362,7 @@
         },
         "committeeSentDate": {
           "$ref": "#/definitions/Date",
-          "description": "YYYY-MM-DD Follows convention of if date in the name it is YYYY-MM-DD the date that the application went to committee"
-        },
-        "councilDecision": {
-          "$ref": "#/definitions/AssessmentDecision",
-          "description": "This is the decision made by the council"
-        },
-        "councilDecisionDate": {
-          "$ref": "#/definitions/Date",
-          "description": "YYYY-MM-DD This is the date the decision was made by the council"
-        },
-        "councilRecommendation": {
-          "$ref": "#/definitions/AssessmentDecision",
-          "description": "This is the recommendation made by a council to the committee This is an alternative to a decision - either councilDecision or councilRecommendation can be set not both"
+          "description": "YYYY-MM-DD Follows convention of if date in the name it is YYYY-MM-DD the date that the application went to committee it is also the date that planningOfficerRecommendation was set"
         },
         "decisionNotice": {
           "additionalProperties": false,
@@ -388,6 +376,18 @@
             "url"
           ],
           "type": "object"
+        },
+        "planningOfficerDecision": {
+          "$ref": "#/definitions/AssessmentDecision",
+          "description": "This is the decision made by planning officer(s) in a LPA"
+        },
+        "planningOfficerDecisionDate": {
+          "$ref": "#/definitions/Date",
+          "description": "YYYY-MM-DD This is the date the decision was made by planning officer(s) in a LPA"
+        },
+        "planningOfficerRecommendation": {
+          "$ref": "#/definitions/AssessmentDecision",
+          "description": "This is the recommendation made by planning officer(s) to the committee This is an alternative to a decision - either planningOfficerDecision or planningOfficerRecommendation can be set not both"
         }
       },
       "type": "object"
@@ -15505,19 +15505,7 @@
         },
         "committeeSentDate": {
           "$ref": "#/definitions/Date",
-          "description": "YYYY-MM-DD Follows convention of if date in the name it is YYYY-MM-DD the date that the application went to committee"
-        },
-        "councilDecision": {
-          "$ref": "#/definitions/AssessmentDecision",
-          "description": "This is the decision made by the council"
-        },
-        "councilDecisionDate": {
-          "$ref": "#/definitions/Date",
-          "description": "YYYY-MM-DD This is the date the decision was made by the council"
-        },
-        "councilRecommendation": {
-          "$ref": "#/definitions/AssessmentDecision",
-          "description": "This is the recommendation made by a council to the committee This is an alternative to a decision - either councilDecision or councilRecommendation can be set not both"
+          "description": "YYYY-MM-DD Follows convention of if date in the name it is YYYY-MM-DD the date that the application went to committee it is also the date that planningOfficerRecommendation was set"
         },
         "decisionNotice": {
           "additionalProperties": false,
@@ -15532,8 +15520,20 @@
           ],
           "type": "object"
         },
+        "planningOfficerDecision": {
+          "$ref": "#/definitions/AssessmentDecision",
+          "description": "This is the decision made by planning officer(s) in a LPA"
+        },
+        "planningOfficerDecisionDate": {
+          "$ref": "#/definitions/Date",
+          "description": "YYYY-MM-DD This is the date the decision was made by planning officer(s) in a LPA"
+        },
+        "planningOfficerRecommendation": {
+          "$ref": "#/definitions/AssessmentDecision",
+          "description": "This is the recommendation made by planning officer(s) to the committee This is an alternative to a decision - either planningOfficerDecision or planningOfficerRecommendation can be set not both"
+        },
         "priorApprovalRequired": {
-          "description": "Only applies for prior approval applications so we can say 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused';",
+          "description": "Only applies for prior approval applications so we can work out 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused'",
           "type": "boolean"
         }
       },

--- a/types/schemas/postSubmissionApplication/README.md
+++ b/types/schemas/postSubmissionApplication/README.md
@@ -251,7 +251,31 @@ Not all application types have consultation periods - this is something that wil
 
 ### data.assessment?
 
-Assessment is when the council and optionally a committee make a decision. `councilDecision`, `committeeSentDate` and `committeeDecision`
+Assessment is when the council and optionally a committee make a decision. The specification differentiates between `planningOfficerDecision` and `committeeDecision` on purpose in order to show our workings as to how the council decision was arrived at.
+
+`Council decision = planningOfficerDecision || committeeDecision`
+
+We don't show council decision as its own field as its too prone to errors and is a duplication of data.
+
+An application in assessment can have either `planningOfficerDecision` or `planningOfficerRecommendation + CommitteeDecision`
+
+```json
+{
+  "planningOfficerDecision": "granted",
+  "planningOfficerDecisionDate": "2024-03-21"
+}
+```
+
+or
+
+```json
+{
+  "planningOfficerRecommendation": "granted",
+  "committeeSentDate": "2024-03-21",
+  "committeeDecision": "granted",
+  "committeeDecisionDate": "2024-04-01"
+}
+```
 
 If an application is Prior Approval it also has `priorApprovalRequired` since they can be 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused'
 

--- a/types/schemas/postSubmissionApplication/data/Assessment.ts
+++ b/types/schemas/postSubmissionApplication/data/Assessment.ts
@@ -3,28 +3,29 @@ import {PrimaryApplicationType} from '../../prototypeApplication/enums/Applicati
 import {AssessmentDecision} from '../enums/AssessmentDecision';
 
 /**
- * 'Granted', 'Refused', 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused';
+ * Council decision is planningOfficerDecision || committeeDecision
+ * Council decision date is planningOfficerDecisionDate || committeeDecisionDate
  */
 export type AssessmentBase = {
   /**
-   * This is the decision made by the council
+   * This is the decision made by planning officer(s) in a LPA
    */
-  councilDecision?: AssessmentDecision;
+  planningOfficerDecision?: AssessmentDecision;
   /**
    * YYYY-MM-DD
-   * This is the date the decision was made by the council
+   * This is the date the decision was made by planning officer(s) in a LPA
    */
-  councilDecisionDate?: Date;
+  planningOfficerDecisionDate?: Date;
 
   /**
-   * This is the recommendation made by a council to the committee
-   * This is an alternative to a decision - either councilDecision or councilRecommendation can be set not both
+   * This is the recommendation made by planning officer(s) to the committee
+   * This is an alternative to a decision - either planningOfficerDecision or planningOfficerRecommendation can be set not both
    */
-  councilRecommendation?: AssessmentDecision;
+  planningOfficerRecommendation?: AssessmentDecision;
   /**
    * YYYY-MM-DD
    * Follows convention of if date in the name it is YYYY-MM-DD
-   * the date that the application went to committee
+   * the date that the application went to committee it is also the date that planningOfficerRecommendation was set
    */
   committeeSentDate?: Date;
   /**
@@ -49,7 +50,8 @@ export type AssessmentBase = {
 
 export type PriorApprovalAssessment = AssessmentBase & {
   /**
-   * Only applies for prior approval applications so we can say 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused';
+   * Only applies for prior approval applications so we can work out
+   * 'Prior approval required and approved', 'Prior approval not required', 'Prior approval required and refused'
    */
   priorApprovalRequired: boolean;
 };

--- a/types/schemas/postSubmissionApplication/lib/realisticDates.ts
+++ b/types/schemas/postSubmissionApplication/lib/realisticDates.ts
@@ -15,7 +15,7 @@ type RealisticDates = {
     endAt: Date;
   };
   assessment: {
-    councilDecisionAt: Date;
+    planningOfficerDecisionAt: Date;
     committeeSentAt: Date;
     committeeDecisionAt: Date;
   };
@@ -67,10 +67,10 @@ export const generateRealisticDates = (
   const consultationEndAt = addDays(consultationStartAt, 21);
 
   // the council decision is made sometime after the consultation ends
-  const councilDecisionAt = addDays(consultationEndAt, 10);
+  const planningOfficerDecisionAt = addDays(consultationEndAt, 10);
 
-  // if it's sent to committee it's sent after the council decision
-  const committeeSentAt = addDays(councilDecisionAt, 1);
+  // if it's sent to committee it's sent after the council recommendation is made
+  const committeeSentAt = addDays(planningOfficerDecisionAt, 1);
 
   // after it's sent to the committee the decision is made after that date
   const committeeDecisionAt = addDays(committeeSentAt, 10);
@@ -88,7 +88,7 @@ export const generateRealisticDates = (
   // appeal decided
   const appealDecidedAt = addDays(appealStartedAt, 5);
 
-  // application can be withdrawn any time between consultationStartAt and councilDecisionAt
+  // application can be withdrawn any time between consultationStartAt and planningOfficerDecisionAt
   const withdrawnAt = addDays(consultationStartAt, 1);
 
   // appeal is withdrawn any time between appealLodgedAt and appealDecidedAt
@@ -111,7 +111,7 @@ export const generateRealisticDates = (
       endAt: consultationEndAt,
     },
     assessment: {
-      councilDecisionAt: councilDecisionAt,
+      planningOfficerDecisionAt: planningOfficerDecisionAt,
       committeeSentAt: committeeSentAt,
       committeeDecisionAt: committeeDecisionAt,
     },


### PR DESCRIPTION
The naming of the `assessment.councilDecision` and `assessment.councilRecommendation` field's was causing some confusion. The term `Council decision` refers to the final decision of the assessment process regardless of who made the decision. 

On the DPR we're very specific about the language we use to refer to things so we want to include that clarity in the specification. 

<img width="648" alt="image" src="https://github.com/user-attachments/assets/dc12c3f3-d164-474a-942b-0518f6712acd" />

This PR changes
- `councilDecision` to `planningOfficerDecision`
- `councilDecisionDate` to `planningOfficerDecisionDate`
- Updates the relevant documentation to reflect the changes and the reasons for the names

More information from the README in this commit:

Assessment is when the council and optionally a committee make a decision. The specification differentiates between `planningOfficerDecision` and `committeeDecision` on purpose in order to show our workings as to how the council decision was arrived at.

`Council decision = planningOfficerDecision || committeeDecision`

We don't show council decision as its own field as its too prone to errors and is a duplication of data.

An application in assessment can have either `planningOfficerDecision` or `planningOfficerRecommendation + CommitteeDecision`

```json
{
  "planningOfficerDecision": "granted",
  "planningOfficerDecisionDate": "2024-03-21"
}
```

or

```json
{
  "planningOfficerRecommendation": "granted",
  "committeeSentDate": "2024-03-21",
  "committeeDecision": "granted",
  "committeeDecisionDate": "2024-04-01"
}
```
