### PR TITLE
Fix for duplicate ApiResponse type

### DIFF
--- a/types/schemas/postSubmissionApplication/implementation/ApiResponse.ts
+++ b/types/schemas/postSubmissionApplication/implementation/ApiResponse.ts
@@ -1,5 +1,8 @@
 import {CursorPagination, Pagination} from './Pagination';
 
+/**
+ * @description #ApiResponse
+ */
 export interface ApiResponse<T> {
   data: T | null;
   pagination?: Pagination | CursorPagination;

--- a/types/schemas/postSubmissionApplication/implementation/Pagination.ts
+++ b/types/schemas/postSubmissionApplication/implementation/Pagination.ts
@@ -41,16 +41,3 @@ export interface CursorPagination {
    */
   totalItems: number;
 }
-
-/**
- * @description #ApiResponse
- */
-export interface ApiResponse<T> {
-  data: T | null;
-  pagination?: Pagination | CursorPagination;
-  status?: {
-    code: number;
-    message: string;
-    detail?: string;
-  };
-}


### PR DESCRIPTION
I didn't notice that I had included ApiResponse twice in my other PR. 🤦‍♀️

This PR 

* removes duplicate ApiResponse from Pagination.ts file
* updates ApiResponse in ApiResponse file to include description