### PR TITLE
feat: add `battlefield` to `PlanningDesignations` enum

### DIFF
--- a/schemas/application.json
+++ b/schemas/application.json
@@ -9047,6 +9047,29 @@
               "additionalProperties": false,
               "properties": {
                 "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
                   "const": "Brownfield site",
                   "type": "string"
                 },
@@ -10674,6 +10697,35 @@
                 },
                 "value": {
                   "const": "aquifer.secondary",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
                   "type": "string"
                 }
               },

--- a/schemas/postSubmissionApplication.json
+++ b/schemas/postSubmissionApplication.json
@@ -1019,6 +1019,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Historic battlefield",
+              "type": "string"
+            },
+            "value": {
+              "const": "battlefield",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Brownfield site",
               "type": "string"
             },
@@ -8985,6 +9003,29 @@
               "additionalProperties": false,
               "properties": {
                 "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
                   "const": "Brownfield site",
                   "type": "string"
                 },
@@ -10612,6 +10653,35 @@
                 },
                 "value": {
                   "const": "aquifer.secondary",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
                   "type": "string"
                 }
               },

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -3315,6 +3315,29 @@
               "additionalProperties": false,
               "properties": {
                 "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
                   "const": "Brownfield site",
                   "type": "string"
                 },
@@ -4942,6 +4965,35 @@
                 },
                 "value": {
                   "const": "aquifer.secondary",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
                   "type": "string"
                 }
               },

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -889,6 +889,24 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Historic battlefield",
+              "type": "string"
+            },
+            "value": {
+              "const": "battlefield",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Brownfield site",
               "type": "string"
             },
@@ -8645,6 +8663,29 @@
               "additionalProperties": false,
               "properties": {
                 "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
                   "const": "Brownfield site",
                   "type": "string"
                 },
@@ -10272,6 +10313,35 @@
                 },
                 "value": {
                   "const": "aquifer.secondary",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Historic battlefield",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "battlefield",
                   "type": "string"
                 }
               },

--- a/types/shared/Constraints.ts
+++ b/types/shared/Constraints.ts
@@ -13,6 +13,7 @@ export const PlanningDesignations = {
   aquifer: 'Aquifer',
   'aquifer.principal': 'Principal aquifer',
   'aquifer.secondary': 'Secondary aquifer',
+  battlefield: 'Historic battlefield',
   brownfieldSite: 'Brownfield site',
   coastalChangeManagementArea: 'Coastal change management area',
   communityAsset: 'Community asset',


### PR DESCRIPTION
Will fetch and populated based on source data here: https://www.planning.data.gov.uk/dataset/battlefield

Comes by request of Tewkesbury, battlefields don't impact PD rights but they are of interest during assessment