### PR TITLE
chore: refactor `PrototypeApplication` "applicant" to chain modular types

### DIFF
--- a/examples/postSubmissionApplication/priorApproval/largerExtension-01-submission.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-01-submission.json
@@ -34,9 +34,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-02-validation-01-invalid.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-02-validation-01-invalid.json
@@ -39,9 +39,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-03-consultation.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-03-consultation.json
@@ -347,9 +347,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-00-assessment-in-progress.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-00-assessment-in-progress.json
@@ -350,9 +350,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-01-council-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-01-council-determined.json
@@ -356,9 +356,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.json
@@ -353,9 +353,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-03-committee-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-03-committee-determined.json
@@ -358,9 +358,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-00-appeal-lodged.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-00-appeal-lodged.json
@@ -360,9 +360,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-01-appeal-validated.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-01-appeal-validated.json
@@ -361,9 +361,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-02-appeal-started.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-02-appeal-started.json
@@ -362,9 +362,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-03-appeal-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-03-appeal-determined.json
@@ -364,9 +364,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-06-assessment-withdrawn.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-06-assessment-withdrawn.json
@@ -352,9 +352,6 @@
         },
         "address": {
           "sameAsSiteAddress": true
-        },
-        "siteContact": {
-          "role": "applicant"
         }
       },
       "property": {

--- a/examples/prototypeApplication/complianceConfirmation.json
+++ b/examples/prototypeApplication/complianceConfirmation.json
@@ -19,9 +19,6 @@
       "address": {
         "sameAsSiteAddress": true
       },
-      "siteContact": {
-        "role": "applicant"
-      },
       "ownership": {
         "interest": "owner"
       }

--- a/examples/prototypeApplication/data/complianceConfirmation.ts
+++ b/examples/prototypeApplication/data/complianceConfirmation.ts
@@ -23,9 +23,6 @@ export const complianceConfirmationPrototype: PrototypeApplication = {
       address: {
         sameAsSiteAddress: true,
       },
-      siteContact: {
-        role: 'applicant',
-      },
       ownership: {
         interest: 'owner',
       },

--- a/examples/prototypeApplication/data/landDrainageConsent.ts
+++ b/examples/prototypeApplication/data/landDrainageConsent.ts
@@ -25,9 +25,6 @@ export const landDrainageConsentPrototype: PrototypeApplication = {
       address: {
         sameAsSiteAddress: true,
       },
-      siteContact: {
-        role: 'applicant',
-      },
       ownership: {
         interest: 'other',
       },

--- a/examples/prototypeApplication/data/priorApproval/buildHomes.ts
+++ b/examples/prototypeApplication/data/priorApproval/buildHomes.ts
@@ -21,9 +21,6 @@ export const priorApprovalBuildHomesPrototype: PrototypeApplication = {
       address: {
         sameAsSiteAddress: true,
       },
-      siteContact: {
-        role: 'applicant',
-      },
     },
     property: {
       address: {

--- a/examples/prototypeApplication/data/priorApproval/convertCommercialToHome.ts
+++ b/examples/prototypeApplication/data/priorApproval/convertCommercialToHome.ts
@@ -22,9 +22,6 @@ export const priorApprovalConvertCommercialToHomePrototype: PrototypeApplication
         address: {
           sameAsSiteAddress: true,
         },
-        siteContact: {
-          role: 'agent',
-        },
         agent: {
           name: {
             first: 'Alan',

--- a/examples/prototypeApplication/data/priorApproval/extendUniversity.ts
+++ b/examples/prototypeApplication/data/priorApproval/extendUniversity.ts
@@ -21,9 +21,6 @@ export const priorApprovalExtendUniversityPrototype: PrototypeApplication = {
       address: {
         sameAsSiteAddress: true,
       },
-      siteContact: {
-        role: 'applicant',
-      },
     },
     property: {
       address: {

--- a/examples/prototypeApplication/data/priorApproval/largerExtension.ts
+++ b/examples/prototypeApplication/data/priorApproval/largerExtension.ts
@@ -21,9 +21,6 @@ export const priorApprovalLargerExtensionPrototype: PrototypeApplication = {
       address: {
         sameAsSiteAddress: true,
       },
-      siteContact: {
-        role: 'applicant',
-      },
     },
     property: {
       address: {

--- a/examples/prototypeApplication/data/priorApproval/solarPanels.ts
+++ b/examples/prototypeApplication/data/priorApproval/solarPanels.ts
@@ -21,9 +21,6 @@ export const priorApprovalSolarPanelsPrototype: PrototypeApplication = {
       address: {
         sameAsSiteAddress: true,
       },
-      siteContact: {
-        role: 'applicant',
-      },
     },
     property: {
       address: {

--- a/examples/prototypeApplication/landDrainageConsent.json
+++ b/examples/prototypeApplication/landDrainageConsent.json
@@ -21,9 +21,6 @@
       "address": {
         "sameAsSiteAddress": true
       },
-      "siteContact": {
-        "role": "applicant"
-      },
       "ownership": {
         "interest": "other"
       },

--- a/examples/prototypeApplication/priorApproval/buildHomes.json
+++ b/examples/prototypeApplication/priorApproval/buildHomes.json
@@ -16,9 +16,6 @@
       },
       "address": {
         "sameAsSiteAddress": true
-      },
-      "siteContact": {
-        "role": "applicant"
       }
     },
     "property": {

--- a/examples/prototypeApplication/priorApproval/convertCommercialToHome.json
+++ b/examples/prototypeApplication/priorApproval/convertCommercialToHome.json
@@ -17,9 +17,6 @@
       "address": {
         "sameAsSiteAddress": true
       },
-      "siteContact": {
-        "role": "agent"
-      },
       "agent": {
         "name": {
           "first": "Alan",

--- a/examples/prototypeApplication/priorApproval/extendUniversity.json
+++ b/examples/prototypeApplication/priorApproval/extendUniversity.json
@@ -16,9 +16,6 @@
       },
       "address": {
         "sameAsSiteAddress": true
-      },
-      "siteContact": {
-        "role": "applicant"
       }
     },
     "property": {

--- a/examples/prototypeApplication/priorApproval/largerExtension.json
+++ b/examples/prototypeApplication/priorApproval/largerExtension.json
@@ -16,9 +16,6 @@
       },
       "address": {
         "sameAsSiteAddress": true
-      },
-      "siteContact": {
-        "role": "applicant"
       }
     },
     "property": {

--- a/examples/prototypeApplication/priorApproval/solarPanels.json
+++ b/examples/prototypeApplication/priorApproval/solarPanels.json
@@ -16,9 +16,6 @@
       },
       "address": {
         "sameAsSiteAddress": true
-      },
-      "siteContact": {
-        "role": "applicant"
       }
     },
     "property": {

--- a/schemas/application.json
+++ b/schemas/application.json
@@ -119,7 +119,32 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContacts"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "$ref": "#/definitions/Address"
+              },
+              "contact": {
+                "$ref": "#/definitions/ContactDetails"
+              },
+              "when": {
+                "enum": [
+                  "duringConstruction",
+                  "afterConstruction",
+                  "duringAndAfterConstruction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "when",
+              "address",
+              "contact"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "name": {
           "additionalProperties": false,
@@ -156,7 +181,28 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": [
+                    "applicant",
+                    "agent",
+                    "proxy"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "role"
+              ],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -2195,7 +2241,32 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContacts"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "$ref": "#/definitions/Address"
+              },
+              "contact": {
+                "$ref": "#/definitions/ContactDetails"
+              },
+              "when": {
+                "enum": [
+                  "duringConstruction",
+                  "afterConstruction",
+                  "duringAndAfterConstruction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "when",
+              "address",
+              "contact"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "name": {
           "additionalProperties": false,
@@ -2232,7 +2303,28 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": [
+                    "applicant",
+                    "agent",
+                    "proxy"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "role"
+              ],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -7872,36 +7964,6 @@
       ],
       "type": "object"
     },
-    "MaintenanceContacts": {
-      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "address": {
-            "$ref": "#/definitions/Address"
-          },
-          "contact": {
-            "$ref": "#/definitions/ContactDetails"
-          },
-          "when": {
-            "enum": [
-              "duringConstruction",
-              "afterConstruction",
-              "duringAndAfterConstruction"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "when",
-          "address",
-          "contact"
-        ],
-        "type": "object"
-      },
-      "title": "Maintenance contacts",
-      "type": "array"
-    },
     "Materials": {
       "additionalProperties": false,
       "properties": {
@@ -8537,6 +8599,8 @@
     "OwnersInterest": {
       "enum": [
         "owner",
+        "owner.sole",
+        "owner.co",
         "lessee",
         "occupier",
         "other"
@@ -8649,19 +8713,7 @@
           "type": "object"
         },
         "interest": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OwnersInterest"
-            },
-            {
-              "const": "owner.sole",
-              "type": "string"
-            },
-            {
-              "const": "owner.co",
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/OwnersInterest"
         },
         "interestDescription": {
           "type": "string"
@@ -30108,32 +30160,6 @@
       ],
       "description": "The result of a single flagset"
     },
-    "SiteContact": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "role": {
-              "enum": [
-                "applicant",
-                "agent",
-                "proxy"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "role"
-          ],
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/SiteContactOther"
-        }
-      ],
-      "description": "Contact information for the site visit",
-      "title": "Site contact"
-    },
     "SiteContactOther": {
       "additionalProperties": false,
       "description": "Contact information for the site visit when the SiteContact's role is 'other'",
@@ -30158,6 +30184,7 @@
         "email",
         "phone"
       ],
+      "title": "Site contact other",
       "type": "object"
     },
     "UKProperty": {

--- a/schemas/postSubmissionApplication.json
+++ b/schemas/postSubmissionApplication.json
@@ -320,278 +320,348 @@
       "title": "Contact address",
       "type": "object"
     },
-    "AdvertConsentApplicant": {
-      "anyOf": [
-        {
+    "AdvertConsent": {
+      "additionalProperties": false,
+      "properties": {
+        "applicationType": {
+          "const": "advertConsent",
+          "type": "string"
+        },
+        "data": {
           "additionalProperties": false,
           "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
+            "applicant": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
                     },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
                     },
-                    {
-                      "const": "owner.co",
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
                       "type": "string"
                     }
-                  ]
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
                 }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
+              ]
             },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
+            "application": {
+              "$ref": "#/definitions/FeeCarryingApplicationData"
             },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+            "property": {
+              "$ref": "#/definitions/EnglandProperty"
             },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
+            "proposal": {
+              "$ref": "#/definitions/AdvertConsentProposal"
+            },
+            "user": {
+              "$ref": "#/definitions/UserBase"
             }
           },
           "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
+            "user",
+            "applicant",
+            "application",
+            "property",
+            "proposal"
           ],
           "type": "object"
         },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
+        "files": {
+          "items": {
+            "$ref": "#/definitions/File"
           },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/definitions/PrototypePlanXMetadata"
+        },
+        "responses": {
+          "$ref": "#/definitions/Responses"
         }
-      ]
+      },
+      "required": [
+        "applicationType",
+        "data",
+        "responses",
+        "files",
+        "metadata"
+      ],
+      "type": "object"
     },
     "AdvertConsentProposal": {
       "additionalProperties": false,
@@ -664,147 +734,6 @@
         "highwayProjection",
         "otherAdvertisements",
         "visibility"
-      ],
-      "type": "object"
-    },
-    "Agent": {
-      "additionalProperties": false,
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/UserAddress",
-          "description": "Address information for the applicant"
-        },
-        "agent": {
-          "additionalProperties": false,
-          "description": "Contact information for the agent or proxy",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/Address"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "phone"
-          ],
-          "type": "object"
-        },
-        "company": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "type": "object"
-        },
-        "email": {
-          "$ref": "#/definitions/Email"
-        },
-        "name": {
-          "additionalProperties": false,
-          "properties": {
-            "first": {
-              "type": "string"
-            },
-            "last": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "first",
-            "last"
-          ],
-          "type": "object"
-        },
-        "phone": {
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "primary"
-          ],
-          "type": "object"
-        },
-        "siteContact": {
-          "$ref": "#/definitions/SiteContact",
-          "description": "Contact information for the site visit"
-        },
-        "type": {
-          "description": "The type of applicant",
-          "enum": [
-            "individual",
-            "company",
-            "charity",
-            "public",
-            "parishCouncil"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "address",
-        "agent",
-        "email",
-        "name",
-        "phone",
-        "siteContact"
       ],
       "type": "object"
     },
@@ -954,9 +883,147 @@
           "$ref": "#/definitions/BaseApplicant"
         },
         {
-          "$ref": "#/definitions/Agent"
+          "$ref": "#/definitions/ApplicantWithAgent"
         }
       ]
+    },
+    "ApplicantWithAgent": {
+      "additionalProperties": false,
+      "description": "Details about the applicant and the agent or proxy applying on their behalf",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/UserAddress",
+          "description": "Address information for the applicant"
+        },
+        "agent": {
+          "additionalProperties": false,
+          "description": "Contact information for the agent or proxy",
+          "properties": {
+            "address": {
+              "$ref": "#/definitions/Address"
+            },
+            "company": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "email": {
+              "$ref": "#/definitions/Email"
+            },
+            "name": {
+              "additionalProperties": false,
+              "properties": {
+                "first": {
+                  "type": "string"
+                },
+                "last": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "first",
+                "last"
+              ],
+              "type": "object"
+            },
+            "phone": {
+              "additionalProperties": false,
+              "properties": {
+                "primary": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "primary"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "address",
+            "email",
+            "name",
+            "phone"
+          ],
+          "type": "object"
+        },
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "description": "The type of applicant",
+          "enum": [
+            "individual",
+            "company",
+            "charity",
+            "public",
+            "parishCouncil"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "agent",
+        "email",
+        "name",
+        "phone"
+      ],
+      "title": "Applicant with agent",
+      "type": "object"
     },
     "ApplicationDataBase": {
       "anyOf": [
@@ -1163,6 +1230,7 @@
     },
     "BaseApplicant": {
       "additionalProperties": false,
+      "description": "Details about the applicant",
       "properties": {
         "address": {
           "$ref": "#/definitions/UserAddress",
@@ -1214,10 +1282,6 @@
           ],
           "type": "object"
         },
-        "siteContact": {
-          "$ref": "#/definitions/SiteContact",
-          "description": "Contact information for the site visit"
-        },
         "type": {
           "description": "The type of applicant",
           "enum": [
@@ -1234,9 +1298,9 @@
         "address",
         "email",
         "name",
-        "phone",
-        "siteContact"
+        "phone"
       ],
+      "title": "Applicant",
       "type": "object"
     },
     "BasePlanningDesignation": {
@@ -3023,7 +3087,243 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/ComplianceConfirmationApplicant"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                }
+              ]
             },
             "application": {
               "$ref": "#/definitions/FeeCarryingApplicationData"
@@ -3068,279 +3368,6 @@
         "metadata"
       ],
       "type": "object"
-    },
-    "ComplianceConfirmationApplicant": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        }
-      ]
     },
     "ContactDetails": {
       "additionalProperties": false,
@@ -5066,7 +5093,293 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/HedgerowRemovalNoticeApplicant"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
+                }
+              ]
             },
             "application": {
               "$ref": "#/definitions/NonFeeCarryingApplicationData"
@@ -5111,279 +5424,6 @@
         "metadata"
       ],
       "type": "object"
-    },
-    "HedgerowRemovalNoticeApplicant": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        }
-      ]
     },
     "HedgerowRemovalNoticeProposal": {
       "additionalProperties": false,
@@ -5553,8 +5593,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -5769,8 +5829,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -5808,7 +5888,299 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/LandDrainageConsentApplicant"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "maintenanceContact": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "address": {
+                            "$ref": "#/definitions/Address"
+                          },
+                          "contact": {
+                            "$ref": "#/definitions/ContactDetails"
+                          },
+                          "when": {
+                            "enum": [
+                              "duringConstruction",
+                              "afterConstruction",
+                              "duringAndAfterConstruction"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "when",
+                          "address",
+                          "contact"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "maintenanceContact": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "address": {
+                            "$ref": "#/definitions/Address"
+                          },
+                          "contact": {
+                            "$ref": "#/definitions/ContactDetails"
+                          },
+                          "when": {
+                            "enum": [
+                              "duringConstruction",
+                              "afterConstruction",
+                              "duringAndAfterConstruction"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "when",
+                          "address",
+                          "contact"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                }
+              ]
             },
             "application": {
               "$ref": "#/definitions/FeeCarryingApplicationData"
@@ -5853,287 +6225,6 @@
         "metadata"
       ],
       "type": "object"
-    },
-    "LandDrainageConsentApplicant": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        }
-      ]
     },
     "LawfulDevelopmentCertificateBreachOfCondition": {
       "additionalProperties": false,
@@ -6237,7 +6328,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -6355,7 +6462,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -7585,36 +7708,6 @@
       ],
       "type": "object"
     },
-    "MaintenanceContacts": {
-      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "address": {
-            "$ref": "#/definitions/Address"
-          },
-          "contact": {
-            "$ref": "#/definitions/ContactDetails"
-          },
-          "when": {
-            "enum": [
-              "duringConstruction",
-              "afterConstruction",
-              "duringAndAfterConstruction"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "when",
-          "address",
-          "contact"
-        ],
-        "type": "object"
-      },
-      "title": "Maintenance contacts",
-      "type": "array"
-    },
     "Materials": {
       "additionalProperties": false,
       "properties": {
@@ -8556,6 +8649,8 @@
     "OwnersInterest": {
       "enum": [
         "owner",
+        "owner.sole",
+        "owner.co",
         "lessee",
         "occupier",
         "other"
@@ -8661,8 +8756,32 @@
               "$ref": "#/definitions/Email"
             },
             "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "$ref": "#/definitions/Address"
+                  },
+                  "contact": {
+                    "$ref": "#/definitions/ContactDetails"
+                  },
+                  "when": {
+                    "enum": [
+                      "duringConstruction",
+                      "afterConstruction",
+                      "duringAndAfterConstruction"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "when",
+                  "address",
+                  "contact"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             },
             "name": {
               "additionalProperties": false,
@@ -8715,19 +8834,7 @@
                   "type": "object"
                 },
                 "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
+                  "$ref": "#/definitions/OwnersInterest"
                 },
                 "noticeGiven": {
                   "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
@@ -8788,8 +8895,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -8898,8 +9025,32 @@
               "$ref": "#/definitions/Email"
             },
             "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "$ref": "#/definitions/Address"
+                  },
+                  "contact": {
+                    "$ref": "#/definitions/ContactDetails"
+                  },
+                  "when": {
+                    "enum": [
+                      "duringConstruction",
+                      "afterConstruction",
+                      "duringAndAfterConstruction"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "when",
+                  "address",
+                  "contact"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             },
             "name": {
               "additionalProperties": false,
@@ -8952,19 +9103,7 @@
                   "type": "object"
                 },
                 "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
+                  "$ref": "#/definitions/OwnersInterest"
                 },
                 "noticeGiven": {
                   "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
@@ -9025,8 +9164,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -33334,27 +33493,6 @@
       "title": "Pre-application",
       "type": "object"
     },
-    "PreAssessment": {
-      "$id": "#PreAssessment",
-      "description": "The result of the application based on information provided by the applicant, prior to assessment by a planning officer. Results are determined by flags corresponding to responses; each application can have up to one result per flagset",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "value",
-          "description"
-        ],
-        "type": "object"
-      },
-      "type": "array"
-    },
     "PriorApprovalAssessment": {
       "additionalProperties": false,
       "description": "Assessment for a post submission application with type prior approval",
@@ -33455,7 +33593,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33516,7 +33670,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33577,7 +33747,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33638,7 +33824,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33699,7 +33901,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33760,7 +33978,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33821,7 +34055,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33882,7 +34132,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -33943,7 +34209,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34004,7 +34286,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34065,7 +34363,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34126,7 +34440,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34187,7 +34517,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34248,7 +34594,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34309,7 +34671,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34370,7 +34748,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34431,7 +34825,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34492,7 +34902,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34553,7 +34979,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34614,7 +35056,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34675,7 +35133,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34736,7 +35210,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34797,7 +35287,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34858,7 +35364,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34919,7 +35441,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -34980,7 +35518,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35041,7 +35595,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35102,7 +35672,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35163,7 +35749,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35224,7 +35826,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35285,7 +35903,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35346,7 +35980,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35407,7 +36057,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35468,7 +36134,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35529,7 +36211,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35590,7 +36288,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35651,7 +36365,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35712,7 +36442,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35773,7 +36519,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35834,7 +36596,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -35895,7 +36673,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -40032,61 +40826,7 @@
     "PrototypeApplication": {
       "anyOf": [
         {
-          "additionalProperties": false,
-          "properties": {
-            "applicationType": {
-              "const": "advertConsent",
-              "type": "string"
-            },
-            "data": {
-              "additionalProperties": false,
-              "properties": {
-                "applicant": {
-                  "$ref": "#/definitions/AdvertConsentApplicant"
-                },
-                "application": {
-                  "$ref": "#/definitions/FeeCarryingApplicationData"
-                },
-                "property": {
-                  "$ref": "#/definitions/EnglandProperty"
-                },
-                "proposal": {
-                  "$ref": "#/definitions/AdvertConsentProposal"
-                },
-                "user": {
-                  "$ref": "#/definitions/UserBase"
-                }
-              },
-              "required": [
-                "user",
-                "applicant",
-                "application",
-                "property",
-                "proposal"
-              ],
-              "type": "object"
-            },
-            "files": {
-              "items": {
-                "$ref": "#/definitions/File"
-              },
-              "type": "array"
-            },
-            "metadata": {
-              "$ref": "#/definitions/PrototypePlanXMetadata"
-            },
-            "responses": {
-              "$ref": "#/definitions/Responses"
-            }
-          },
-          "required": [
-            "applicationType",
-            "data",
-            "responses",
-            "files",
-            "metadata"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/AdvertConsent"
         },
         {
           "$ref": "#/definitions/AmendmentMinorMaterial"
@@ -41301,32 +42041,6 @@
       ],
       "type": "object"
     },
-    "SiteContact": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "role": {
-              "enum": [
-                "applicant",
-                "agent",
-                "proxy"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "role"
-          ],
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/SiteContactOther"
-        }
-      ],
-      "description": "Contact information for the site visit",
-      "title": "Site contact"
-    },
     "SiteContactOther": {
       "additionalProperties": false,
       "description": "Contact information for the site visit when the SiteContact's role is 'other'",
@@ -41351,6 +42065,7 @@
         "email",
         "phone"
       ],
+      "title": "Site contact other",
       "type": "object"
     },
     "SpecialistComment": {
@@ -41797,142 +42512,6 @@
       ],
       "type": "string"
     },
-    "WTTApplicant": {
-      "additionalProperties": false,
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/UserAddress",
-          "description": "Address information for the applicant"
-        },
-        "agent": {
-          "additionalProperties": false,
-          "description": "Contact information for the agent or proxy",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/Address"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "phone"
-          ],
-          "type": "object"
-        },
-        "company": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "type": "object"
-        },
-        "email": {
-          "$ref": "#/definitions/Email"
-        },
-        "name": {
-          "additionalProperties": false,
-          "properties": {
-            "first": {
-              "type": "string"
-            },
-            "last": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "first",
-            "last"
-          ],
-          "type": "object"
-        },
-        "phone": {
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "primary"
-          ],
-          "type": "object"
-        },
-        "type": {
-          "description": "The type of applicant",
-          "enum": [
-            "individual",
-            "company",
-            "charity",
-            "public",
-            "parishCouncil"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "email",
-        "phone",
-        "address",
-        "agent"
-      ],
-      "type": "object"
-    },
     "WorksToTreesConsent": {
       "additionalProperties": false,
       "properties": {
@@ -41944,7 +42523,7 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/WTTApplicant"
+              "$ref": "#/definitions/ApplicantBase"
             },
             "application": {
               "$ref": "#/definitions/NonFeeCarryingApplicationData"
@@ -42001,7 +42580,7 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/WTTApplicant"
+              "$ref": "#/definitions/ApplicantBase"
             },
             "application": {
               "$ref": "#/definitions/NonFeeCarryingApplicationData"

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -119,7 +119,32 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContacts"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "$ref": "#/definitions/Address"
+              },
+              "contact": {
+                "$ref": "#/definitions/ContactDetails"
+              },
+              "when": {
+                "enum": [
+                  "duringConstruction",
+                  "afterConstruction",
+                  "duringAndAfterConstruction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "when",
+              "address",
+              "contact"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "name": {
           "additionalProperties": false,
@@ -156,7 +181,28 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": [
+                    "applicant",
+                    "agent",
+                    "proxy"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "role"
+              ],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -272,7 +318,28 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": [
+                    "applicant",
+                    "agent",
+                    "proxy"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "role"
+              ],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -2659,36 +2726,6 @@
       ],
       "type": "object"
     },
-    "MaintenanceContacts": {
-      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "address": {
-            "$ref": "#/definitions/Address"
-          },
-          "contact": {
-            "$ref": "#/definitions/ContactDetails"
-          },
-          "when": {
-            "enum": [
-              "duringConstruction",
-              "afterConstruction",
-              "duringAndAfterConstruction"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "when",
-          "address",
-          "contact"
-        ],
-        "type": "object"
-      },
-      "title": "Maintenance contacts",
-      "type": "array"
-    },
     "MultiLineString": {
       "additionalProperties": false,
       "description": "MultiLineString geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.5",
@@ -2886,6 +2923,8 @@
     "OwnersInterest": {
       "enum": [
         "owner",
+        "owner.sole",
+        "owner.co",
         "lessee",
         "occupier",
         "other"
@@ -2998,19 +3037,7 @@
           "type": "object"
         },
         "interest": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OwnersInterest"
-            },
-            {
-              "const": "owner.sole",
-              "type": "string"
-            },
-            {
-              "const": "owner.co",
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/OwnersInterest"
         },
         "interestDescription": {
           "type": "string"
@@ -18108,32 +18135,6 @@
       },
       "type": "array"
     },
-    "SiteContact": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "role": {
-              "enum": [
-                "applicant",
-                "agent",
-                "proxy"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "role"
-          ],
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/SiteContactOther"
-        }
-      ],
-      "description": "Contact information for the site visit",
-      "title": "Site contact"
-    },
     "SiteContactOther": {
       "additionalProperties": false,
       "description": "Contact information for the site visit when the SiteContact's role is 'other'",
@@ -18158,6 +18159,7 @@
         "email",
         "phone"
       ],
+      "title": "Site contact other",
       "type": "object"
     },
     "URL": {

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -3,61 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "anyOf": [
     {
-      "additionalProperties": false,
-      "properties": {
-        "applicationType": {
-          "const": "advertConsent",
-          "type": "string"
-        },
-        "data": {
-          "additionalProperties": false,
-          "properties": {
-            "applicant": {
-              "$ref": "#/definitions/AdvertConsentApplicant"
-            },
-            "application": {
-              "$ref": "#/definitions/FeeCarryingApplicationData"
-            },
-            "property": {
-              "$ref": "#/definitions/EnglandProperty"
-            },
-            "proposal": {
-              "$ref": "#/definitions/AdvertConsentProposal"
-            },
-            "user": {
-              "$ref": "#/definitions/UserBase"
-            }
-          },
-          "required": [
-            "user",
-            "applicant",
-            "application",
-            "property",
-            "proposal"
-          ],
-          "type": "object"
-        },
-        "files": {
-          "items": {
-            "$ref": "#/definitions/File"
-          },
-          "type": "array"
-        },
-        "metadata": {
-          "$ref": "#/definitions/PrototypePlanXMetadata"
-        },
-        "responses": {
-          "$ref": "#/definitions/Responses"
-        }
-      },
-      "required": [
-        "applicationType",
-        "data",
-        "responses",
-        "files",
-        "metadata"
-      ],
-      "type": "object"
+      "$ref": "#/definitions/AdvertConsent"
     },
     {
       "$ref": "#/definitions/AmendmentMinorMaterial"
@@ -374,278 +320,348 @@
       "title": "Contact address",
       "type": "object"
     },
-    "AdvertConsentApplicant": {
-      "anyOf": [
-        {
+    "AdvertConsent": {
+      "additionalProperties": false,
+      "properties": {
+        "applicationType": {
+          "const": "advertConsent",
+          "type": "string"
+        },
+        "data": {
           "additionalProperties": false,
           "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
+            "applicant": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
                     },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
                     },
-                    {
-                      "const": "owner.co",
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
                       "type": "string"
                     }
-                  ]
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
                 }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
+              ]
             },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
+            "application": {
+              "$ref": "#/definitions/FeeCarryingApplicationData"
             },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+            "property": {
+              "$ref": "#/definitions/EnglandProperty"
             },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
+            "proposal": {
+              "$ref": "#/definitions/AdvertConsentProposal"
+            },
+            "user": {
+              "$ref": "#/definitions/UserBase"
             }
           },
           "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
+            "user",
+            "applicant",
+            "application",
+            "property",
+            "proposal"
           ],
           "type": "object"
         },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
+        "files": {
+          "items": {
+            "$ref": "#/definitions/File"
           },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/definitions/PrototypePlanXMetadata"
+        },
+        "responses": {
+          "$ref": "#/definitions/Responses"
         }
-      ]
+      },
+      "required": [
+        "applicationType",
+        "data",
+        "responses",
+        "files",
+        "metadata"
+      ],
+      "type": "object"
     },
     "AdvertConsentProposal": {
       "additionalProperties": false,
@@ -718,147 +734,6 @@
         "highwayProjection",
         "otherAdvertisements",
         "visibility"
-      ],
-      "type": "object"
-    },
-    "Agent": {
-      "additionalProperties": false,
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/UserAddress",
-          "description": "Address information for the applicant"
-        },
-        "agent": {
-          "additionalProperties": false,
-          "description": "Contact information for the agent or proxy",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/Address"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "phone"
-          ],
-          "type": "object"
-        },
-        "company": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "type": "object"
-        },
-        "email": {
-          "$ref": "#/definitions/Email"
-        },
-        "name": {
-          "additionalProperties": false,
-          "properties": {
-            "first": {
-              "type": "string"
-            },
-            "last": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "first",
-            "last"
-          ],
-          "type": "object"
-        },
-        "phone": {
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "primary"
-          ],
-          "type": "object"
-        },
-        "siteContact": {
-          "$ref": "#/definitions/SiteContact",
-          "description": "Contact information for the site visit"
-        },
-        "type": {
-          "description": "The type of applicant",
-          "enum": [
-            "individual",
-            "company",
-            "charity",
-            "public",
-            "parishCouncil"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "address",
-        "agent",
-        "email",
-        "name",
-        "phone",
-        "siteContact"
       ],
       "type": "object"
     },
@@ -982,9 +857,147 @@
           "$ref": "#/definitions/BaseApplicant"
         },
         {
-          "$ref": "#/definitions/Agent"
+          "$ref": "#/definitions/ApplicantWithAgent"
         }
       ]
+    },
+    "ApplicantWithAgent": {
+      "additionalProperties": false,
+      "description": "Details about the applicant and the agent or proxy applying on their behalf",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/UserAddress",
+          "description": "Address information for the applicant"
+        },
+        "agent": {
+          "additionalProperties": false,
+          "description": "Contact information for the agent or proxy",
+          "properties": {
+            "address": {
+              "$ref": "#/definitions/Address"
+            },
+            "company": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "email": {
+              "$ref": "#/definitions/Email"
+            },
+            "name": {
+              "additionalProperties": false,
+              "properties": {
+                "first": {
+                  "type": "string"
+                },
+                "last": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "first",
+                "last"
+              ],
+              "type": "object"
+            },
+            "phone": {
+              "additionalProperties": false,
+              "properties": {
+                "primary": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "primary"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "address",
+            "email",
+            "name",
+            "phone"
+          ],
+          "type": "object"
+        },
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "description": "The type of applicant",
+          "enum": [
+            "individual",
+            "company",
+            "charity",
+            "public",
+            "parishCouncil"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "agent",
+        "email",
+        "name",
+        "phone"
+      ],
+      "title": "Applicant with agent",
+      "type": "object"
     },
     "ApplicationDataBase": {
       "anyOf": [
@@ -1149,6 +1162,7 @@
     },
     "BaseApplicant": {
       "additionalProperties": false,
+      "description": "Details about the applicant",
       "properties": {
         "address": {
           "$ref": "#/definitions/UserAddress",
@@ -1200,10 +1214,6 @@
           ],
           "type": "object"
         },
-        "siteContact": {
-          "$ref": "#/definitions/SiteContact",
-          "description": "Contact information for the site visit"
-        },
         "type": {
           "description": "The type of applicant",
           "enum": [
@@ -1220,9 +1230,9 @@
         "address",
         "email",
         "name",
-        "phone",
-        "siteContact"
+        "phone"
       ],
+      "title": "Applicant",
       "type": "object"
     },
     "BasePlanningDesignation": {
@@ -2886,7 +2896,243 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/ComplianceConfirmationApplicant"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                }
+              ]
             },
             "application": {
               "$ref": "#/definitions/FeeCarryingApplicationData"
@@ -2931,279 +3177,6 @@
         "metadata"
       ],
       "type": "object"
-    },
-    "ComplianceConfirmationApplicant": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        }
-      ]
     },
     "ContactDetails": {
       "additionalProperties": false,
@@ -4929,7 +4902,293 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/HedgerowRemovalNoticeApplicant"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "siteContact": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "role": {
+                              "enum": [
+                                "applicant",
+                                "agent",
+                                "proxy"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "role"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "$ref": "#/definitions/SiteContactOther"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone",
+                    "siteContact"
+                  ],
+                  "type": "object"
+                }
+              ]
             },
             "application": {
               "$ref": "#/definitions/NonFeeCarryingApplicationData"
@@ -4974,279 +5233,6 @@
         "metadata"
       ],
       "type": "object"
-    },
-    "HedgerowRemovalNoticeApplicant": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        }
-      ]
     },
     "HedgerowRemovalNoticeProposal": {
       "additionalProperties": false,
@@ -5416,8 +5402,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -5632,8 +5638,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -5671,7 +5697,299 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/LandDrainageConsentApplicant"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "maintenanceContact": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "address": {
+                            "$ref": "#/definitions/Address"
+                          },
+                          "contact": {
+                            "$ref": "#/definitions/ContactDetails"
+                          },
+                          "when": {
+                            "enum": [
+                              "duringConstruction",
+                              "afterConstruction",
+                              "duringAndAfterConstruction"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "when",
+                          "address",
+                          "contact"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "address": {
+                      "$ref": "#/definitions/UserAddress",
+                      "description": "Address information for the applicant"
+                    },
+                    "agent": {
+                      "additionalProperties": false,
+                      "description": "Contact information for the agent or proxy",
+                      "properties": {
+                        "address": {
+                          "$ref": "#/definitions/Address"
+                        },
+                        "company": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "email": {
+                          "$ref": "#/definitions/Email"
+                        },
+                        "name": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "first": {
+                              "type": "string"
+                            },
+                            "last": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "first",
+                            "last"
+                          ],
+                          "type": "object"
+                        },
+                        "phone": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "primary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "primary"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "address",
+                        "email",
+                        "name",
+                        "phone"
+                      ],
+                      "type": "object"
+                    },
+                    "company": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "email": {
+                      "$ref": "#/definitions/Email"
+                    },
+                    "maintenanceContact": {
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "address": {
+                            "$ref": "#/definitions/Address"
+                          },
+                          "contact": {
+                            "$ref": "#/definitions/ContactDetails"
+                          },
+                          "when": {
+                            "enum": [
+                              "duringConstruction",
+                              "afterConstruction",
+                              "duringAndAfterConstruction"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "when",
+                          "address",
+                          "contact"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "first",
+                        "last"
+                      ],
+                      "type": "object"
+                    },
+                    "ownership": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "interest": {
+                          "$ref": "#/definitions/OwnersInterest"
+                        }
+                      },
+                      "required": [
+                        "interest"
+                      ],
+                      "type": "object"
+                    },
+                    "phone": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "primary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "primary"
+                      ],
+                      "type": "object"
+                    },
+                    "type": {
+                      "description": "The type of applicant",
+                      "enum": [
+                        "individual",
+                        "company",
+                        "charity",
+                        "public",
+                        "parishCouncil"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "address",
+                    "agent",
+                    "email",
+                    "name",
+                    "ownership",
+                    "phone"
+                  ],
+                  "type": "object"
+                }
+              ]
             },
             "application": {
               "$ref": "#/definitions/FeeCarryingApplicationData"
@@ -5716,287 +6034,6 @@
         "metadata"
       ],
       "type": "object"
-    },
-    "LandDrainageConsentApplicant": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/UserAddress",
-              "description": "Address information for the applicant"
-            },
-            "agent": {
-              "additionalProperties": false,
-              "description": "Contact information for the agent or proxy",
-              "properties": {
-                "address": {
-                  "$ref": "#/definitions/Address"
-                },
-                "company": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object"
-                },
-                "email": {
-                  "$ref": "#/definitions/Email"
-                },
-                "name": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "first": {
-                      "type": "string"
-                    },
-                    "last": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "first",
-                    "last"
-                  ],
-                  "type": "object"
-                },
-                "phone": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "primary": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "primary"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "address",
-                "email",
-                "name",
-                "phone"
-              ],
-              "type": "object"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "ownership": {
-              "additionalProperties": false,
-              "properties": {
-                "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "interest"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            },
-            "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
-            },
-            "type": {
-              "description": "The type of applicant",
-              "enum": [
-                "individual",
-                "company",
-                "charity",
-                "public",
-                "parishCouncil"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "address",
-            "agent",
-            "email",
-            "name",
-            "ownership",
-            "phone",
-            "siteContact"
-          ],
-          "type": "object"
-        }
-      ]
     },
     "LawfulDevelopmentCertificateBreachOfCondition": {
       "additionalProperties": false,
@@ -6100,7 +6137,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -6218,7 +6271,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -7448,36 +7517,6 @@
       ],
       "type": "object"
     },
-    "MaintenanceContacts": {
-      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "address": {
-            "$ref": "#/definitions/Address"
-          },
-          "contact": {
-            "$ref": "#/definitions/ContactDetails"
-          },
-          "when": {
-            "enum": [
-              "duringConstruction",
-              "afterConstruction",
-              "duringAndAfterConstruction"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "when",
-          "address",
-          "contact"
-        ],
-        "type": "object"
-      },
-      "title": "Maintenance contacts",
-      "type": "array"
-    },
     "Materials": {
       "additionalProperties": false,
       "properties": {
@@ -8419,6 +8458,8 @@
     "OwnersInterest": {
       "enum": [
         "owner",
+        "owner.sole",
+        "owner.co",
         "lessee",
         "occupier",
         "other"
@@ -8524,8 +8565,32 @@
               "$ref": "#/definitions/Email"
             },
             "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "$ref": "#/definitions/Address"
+                  },
+                  "contact": {
+                    "$ref": "#/definitions/ContactDetails"
+                  },
+                  "when": {
+                    "enum": [
+                      "duringConstruction",
+                      "afterConstruction",
+                      "duringAndAfterConstruction"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "when",
+                  "address",
+                  "contact"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             },
             "name": {
               "additionalProperties": false,
@@ -8578,19 +8643,7 @@
                   "type": "object"
                 },
                 "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
+                  "$ref": "#/definitions/OwnersInterest"
                 },
                 "noticeGiven": {
                   "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
@@ -8651,8 +8704,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -8761,8 +8834,32 @@
               "$ref": "#/definitions/Email"
             },
             "maintenanceContact": {
-              "$ref": "#/definitions/MaintenanceContacts",
-              "description": "Contact information for the person(s) responsible for maintenace while the works are carried out"
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "address": {
+                    "$ref": "#/definitions/Address"
+                  },
+                  "contact": {
+                    "$ref": "#/definitions/ContactDetails"
+                  },
+                  "when": {
+                    "enum": [
+                      "duringConstruction",
+                      "afterConstruction",
+                      "duringAndAfterConstruction"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "when",
+                  "address",
+                  "contact"
+                ],
+                "type": "object"
+              },
+              "type": "array"
             },
             "name": {
               "additionalProperties": false,
@@ -8815,19 +8912,7 @@
                   "type": "object"
                 },
                 "interest": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/OwnersInterest"
-                    },
-                    {
-                      "const": "owner.sole",
-                      "type": "string"
-                    },
-                    {
-                      "const": "owner.co",
-                      "type": "string"
-                    }
-                  ]
+                  "$ref": "#/definitions/OwnersInterest"
                 },
                 "noticeGiven": {
                   "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
@@ -8888,8 +8973,28 @@
               "type": "object"
             },
             "siteContact": {
-              "$ref": "#/definitions/SiteContact",
-              "description": "Contact information for the site visit"
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "role": {
+                      "enum": [
+                        "applicant",
+                        "agent",
+                        "proxy"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/definitions/SiteContactOther"
+                }
+              ]
             },
             "type": {
               "description": "The type of applicant",
@@ -14551,27 +14656,6 @@
       "title": "Pre-application",
       "type": "object"
     },
-    "PreAssessment": {
-      "$id": "#PreAssessment",
-      "description": "The result of the application based on information provided by the applicant, prior to assessment by a planning officer. Results are determined by flags corresponding to responses; each application can have up to one result per flagset",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "description": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "value",
-          "description"
-        ],
-        "type": "object"
-      },
-      "type": "array"
-    },
     "PriorApprovalPart11ClassB": {
       "additionalProperties": false,
       "properties": {
@@ -14617,7 +14701,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -14678,7 +14778,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -14739,7 +14855,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -14800,7 +14932,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -14861,7 +15009,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -14922,7 +15086,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -14983,7 +15163,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15044,7 +15240,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15105,7 +15317,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15166,7 +15394,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15227,7 +15471,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15288,7 +15548,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15349,7 +15625,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15410,7 +15702,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15471,7 +15779,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15532,7 +15856,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15593,7 +15933,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15654,7 +16010,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15715,7 +16087,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15776,7 +16164,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15837,7 +16241,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15898,7 +16318,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -15959,7 +16395,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16020,7 +16472,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16081,7 +16549,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16142,7 +16626,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16203,7 +16703,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16264,7 +16780,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16325,7 +16857,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16386,7 +16934,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16447,7 +17011,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16508,7 +17088,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16569,7 +17165,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16630,7 +17242,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16691,7 +17319,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16752,7 +17396,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16813,7 +17473,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16874,7 +17550,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16935,7 +17627,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -16996,7 +17704,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -17057,7 +17781,23 @@
           "$ref": "#/definitions/PrototypePlanXMetadata"
         },
         "preAssessment": {
-          "$ref": "#/definitions/PreAssessment"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "description"
+            ],
+            "type": "object"
+          },
+          "type": "array"
         },
         "responses": {
           "$ref": "#/definitions/Responses"
@@ -21991,32 +22731,6 @@
       ],
       "type": "object"
     },
-    "SiteContact": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "role": {
-              "enum": [
-                "applicant",
-                "agent",
-                "proxy"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "role"
-          ],
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/SiteContactOther"
-        }
-      ],
-      "description": "Contact information for the site visit",
-      "title": "Site contact"
-    },
     "SiteContactOther": {
       "additionalProperties": false,
       "description": "Contact information for the site visit when the SiteContact's role is 'other'",
@@ -22041,6 +22755,7 @@
         "email",
         "phone"
       ],
+      "title": "Site contact other",
       "type": "object"
     },
     "UKResidentialUnitType": {
@@ -22323,142 +23038,6 @@
       ],
       "type": "string"
     },
-    "WTTApplicant": {
-      "additionalProperties": false,
-      "properties": {
-        "address": {
-          "$ref": "#/definitions/UserAddress",
-          "description": "Address information for the applicant"
-        },
-        "agent": {
-          "additionalProperties": false,
-          "description": "Contact information for the agent or proxy",
-          "properties": {
-            "address": {
-              "$ref": "#/definitions/Address"
-            },
-            "company": {
-              "additionalProperties": false,
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object"
-            },
-            "email": {
-              "$ref": "#/definitions/Email"
-            },
-            "name": {
-              "additionalProperties": false,
-              "properties": {
-                "first": {
-                  "type": "string"
-                },
-                "last": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "first",
-                "last"
-              ],
-              "type": "object"
-            },
-            "phone": {
-              "additionalProperties": false,
-              "properties": {
-                "primary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "primary"
-              ],
-              "type": "object"
-            }
-          },
-          "required": [
-            "address",
-            "email",
-            "name",
-            "phone"
-          ],
-          "type": "object"
-        },
-        "company": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "type": "object"
-        },
-        "email": {
-          "$ref": "#/definitions/Email"
-        },
-        "name": {
-          "additionalProperties": false,
-          "properties": {
-            "first": {
-              "type": "string"
-            },
-            "last": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "first",
-            "last"
-          ],
-          "type": "object"
-        },
-        "phone": {
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "primary"
-          ],
-          "type": "object"
-        },
-        "type": {
-          "description": "The type of applicant",
-          "enum": [
-            "individual",
-            "company",
-            "charity",
-            "public",
-            "parishCouncil"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "email",
-        "phone",
-        "address",
-        "agent"
-      ],
-      "type": "object"
-    },
     "WorksToTreesConsent": {
       "additionalProperties": false,
       "properties": {
@@ -22470,7 +23049,7 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/WTTApplicant"
+              "$ref": "#/definitions/ApplicantBase"
             },
             "application": {
               "$ref": "#/definitions/NonFeeCarryingApplicationData"
@@ -22527,7 +23106,7 @@
           "additionalProperties": false,
           "properties": {
             "applicant": {
-              "$ref": "#/definitions/WTTApplicant"
+              "$ref": "#/definitions/ApplicantBase"
             },
             "application": {
               "$ref": "#/definitions/NonFeeCarryingApplicationData"

--- a/types/schemas/application/data/Applicant.ts
+++ b/types/schemas/application/data/Applicant.ts
@@ -14,13 +14,13 @@ export type Applicant = BaseApplicant | Agent;
  * @id #BaseApplicant
  * @description Information about the user who completed the application for themself, or information about the person who the user applied on behalf of
  */
-export type BaseApplicant = ContactDetails & {
-  type: 'individual' | 'company' | 'charity' | 'public' | 'parishCouncil';
-  address: UserAddress;
-  ownership?: Ownership;
-  siteContact: SiteContact;
-  maintenanceContact?: MaintenanceContacts;
-};
+export type BaseApplicant = ContactDetails &
+  SiteContact &
+  MaintenanceContacts & {
+    type: 'individual' | 'company' | 'charity' | 'public' | 'parishCouncil';
+    address: UserAddress;
+    ownership?: Ownership;
+  };
 
 /**
  * @id #Agent

--- a/types/schemas/preApplication/data/Applicant.ts
+++ b/types/schemas/preApplication/data/Applicant.ts
@@ -13,8 +13,8 @@ export type PreApplicant = BasePreApplicant | Agent;
  * @id #BasePreApplicant
  * @description Information about the user who completed the pre-application for themself, or information about the person who the user applied on behalf of
  */
-export type BasePreApplicant = ContactDetails & {
-  type: 'individual' | 'company' | 'charity' | 'public' | 'parishCouncil';
-  address: UserAddress;
-  siteContact: SiteContact;
-};
+export type BasePreApplicant = ContactDetails &
+  SiteContact & {
+    type: 'individual' | 'company' | 'charity' | 'public' | 'parishCouncil';
+    address: UserAddress;
+  };

--- a/types/schemas/prototypeApplication/PreAssessment.ts
+++ b/types/schemas/prototypeApplication/PreAssessment.ts
@@ -1,5 +1,0 @@
-/**
- * @id #PreAssessment
- * @description The result of the application based on information provided by the applicant, prior to assessment by a planning officer. Results are determined by flags corresponding to responses; each application can have up to one result per flagset
- */
-export type PreAssessment = {value: string; description: string}[]; // @todo validate/restrict array to one result per flagset

--- a/types/schemas/prototypeApplication/data/Applicant.ts
+++ b/types/schemas/prototypeApplication/data/Applicant.ts
@@ -2,6 +2,7 @@ import {Address, UserAddress} from '../../../shared/Addresses';
 import {ContactDetails} from '../../../shared/Contacts';
 import {MaintenanceContacts} from '../../../shared/MaintenanceContact';
 import {
+  OwnershipInterest,
   OwnersInterest,
   OwnersNoNoticeGiven,
   OwnersNoticeDate,
@@ -11,8 +12,12 @@ import {SiteContact} from '../../../shared/SiteContact';
 import {Date} from '../../../shared/utils';
 import {ApplicationType} from '../enums/ApplicationType';
 
-export type ApplicantBase = BaseApplicant | Agent;
+export type ApplicantBase = BaseApplicant | ApplicantWithAgent;
 
+/**
+ * @title Applicant
+ * @description Details about the applicant
+ */
 export type BaseApplicant = ContactDetails & {
   /**
    * @description The type of applicant
@@ -22,124 +27,95 @@ export type BaseApplicant = ContactDetails & {
    * @description Address information for the applicant
    */
   address: UserAddress;
-  /**
-   * @description Contact information for the site visit
-   */
-  siteContact: SiteContact;
 };
 
-export interface Agent extends BaseApplicant {
+/**
+ * @title Applicant with agent
+ * @description Details about the applicant and the agent or proxy applying on their behalf
+ */
+export type ApplicantWithAgent = BaseApplicant & {
   /**
    * @description Contact information for the agent or proxy
    */
   agent: ContactDetails & {address: Address};
-}
+};
 
-export type LDCApplicant = ApplicantBase & {
-  /**
-   * @description Information about the property owners, if different than the applicant
-   */
-  ownership:
-    | {interest: Extract<OwnersInterest, 'owner'>} // sole owner does not report `owners`
-    | {
-        interest: Extract<OwnersInterest, 'other'>;
-        interestDescription: string; // "other" interest uniquely requires a free text description
-        owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];
-      }
-    | {
-        interest: OwnersInterest; // `Exclude<OwnershipInterest, "owner">` ? But I think you can be co-owner & report other owners?
-        owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];
+export type LDCApplicant = ApplicantBase &
+  SiteContact & {
+    /**
+     * @description Information about the property owners, if different than the applicant
+     */
+    ownership:
+      | {interest: Extract<OwnersInterest, 'owner'>} // sole owner does not report `owners`
+      | {
+          interest: Extract<OwnersInterest, 'other'>;
+          interestDescription: string; // "other" interest uniquely requires a free text description
+          owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];
+        }
+      | {
+          interest: OwnersInterest; // `Exclude<OwnershipInterest, "owner">` ? But I think you can be co-owner & report other owners?
+          owners: (OwnersNoticeGiven | OwnersNoNoticeGiven)[];
+        };
+  };
+
+export type PPApplicant = ApplicantBase &
+  SiteContact &
+  MaintenanceContacts & {
+    /**
+     * @description Information about the ownership certificate and property owners, if different than the applicant
+     */
+    ownership: {
+      interest: OwnersInterest;
+      /**
+       * @description Does the land have any agricultural tenants?
+       */
+      agriculturalTenants?: boolean;
+      /**
+       * @description Has requisite notice been given to all the known owners and agricultural tenants?
+       */
+      noticeGiven?: boolean;
+      /**
+       * @description Has a notice of the application been published in a newspaper circulating in the area where the land is situated?
+       */
+      noticePublished?: {
+        status: boolean;
+        date?: Date;
+        newspaperName?: string;
       };
-};
-
-export type PPApplicant = ApplicantBase & {
-  /**
-   * @description Information about the ownership certificate and property owners, if different than the applicant
-   */
-  ownership: {
-    interest: OwnersInterest | 'owner.sole' | 'owner.co';
-    /**
-     * @description Does the land have any agricultural tenants?
-     */
-    agriculturalTenants?: boolean;
-    /**
-     * @description Has requisite notice been given to all the known owners and agricultural tenants?
-     */
-    noticeGiven?: boolean;
-    /**
-     * @description Has a notice of the application been published in a newspaper circulating in the area where the land is situated?
-     */
-    noticePublished?: {
-      status: boolean;
-      date?: Date;
-      newspaperName?: string;
-    };
-    /**
-     * @description Do you know the names and addresses of all owners and agricultural tenants?
-     */
-    ownersKnown?: 'all' | 'some' | 'none';
-    owners?: OwnersNoticeDate[];
-    certificate: 'a' | 'b' | 'c' | 'd';
-    /**
-     * @description Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice
-     */
-    declaration: {
-      accurate: true;
+      /**
+       * @description Do you know the names and addresses of all owners and agricultural tenants?
+       */
+      ownersKnown?: 'all' | 'some' | 'none';
+      owners?: OwnersNoticeDate[];
+      certificate: 'a' | 'b' | 'c' | 'd';
+      /**
+       * @description Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice
+       */
+      declaration: {
+        accurate: true;
+      };
     };
   };
-  /**
-   * @description Contact information for the person(s) responsible for maintenace while the works are carried out
-   */
-  maintenanceContact?: MaintenanceContacts;
-};
-
-export type LandDrainageConsentApplicant = ApplicantBase & {
-  ownership: {
-    interest: OwnersInterest | 'owner.sole' | 'owner.co';
-  };
-  /** @description Contact information for the person(s) responsible for maintenace while the works are carried out */
-  maintenanceContact?: MaintenanceContacts;
-};
-
-export type WTTApplicant = Omit<ApplicantBase, 'siteContact'>;
-
-export type HedgerowRemovalNoticeApplicant = ApplicantBase & {
-  ownership: {
-    interest: OwnersInterest | 'owner.sole' | 'owner.co';
-  };
-};
-
-export type AdvertConsentApplicant = ApplicantBase & {
-  ownership: {
-    interest: OwnersInterest | 'owner.sole' | 'owner.co';
-  };
-};
-
-export type ComplianceConfirmationApplicant = ApplicantBase & {
-  ownership: {
-    interest: OwnersInterest | 'owner.sole' | 'owner.co';
-  };
-};
 
 /**
  * TypeMap of granular application types to their specific Applicant models
  */
 interface ApplicantVariants {
+  advertConsent: ApplicantBase & SiteContact & OwnershipInterest;
+  complianceConfirmation: ApplicantBase & OwnershipInterest;
+  hedgerowRemovalNotice: ApplicantBase & SiteContact & OwnershipInterest;
+  landDrainageConsent: ApplicantBase & MaintenanceContacts & OwnershipInterest;
   'ldc.breachOfCondition': LDCApplicant;
   'ldc.existing': LDCApplicant;
   'ldc.proposed': LDCApplicant;
   'ldc.worksToListedBuilding': LDCApplicant;
-  'pp.full.householder.retro': PPApplicant;
+  listed: PPApplicant;
   'pp.full.householder': PPApplicant;
+  'pp.full.householder.retro': PPApplicant;
   'pp.full.major': PPApplicant;
   'pp.full.minor': PPApplicant;
-  'wtt.consent': WTTApplicant;
-  'wtt.notice': WTTApplicant;
-  advertConsent: AdvertConsentApplicant;
-  complianceConfirmation: ComplianceConfirmationApplicant;
-  hedgerowRemovalNotice: HedgerowRemovalNoticeApplicant;
-  landDrainageConsent: LandDrainageConsentApplicant;
-  listed: PPApplicant;
+  'wtt.consent': ApplicantBase;
+  'wtt.notice': ApplicantBase;
 }
 
 /**

--- a/types/schemas/prototypeApplication/index.ts
+++ b/types/schemas/prototypeApplication/index.ts
@@ -7,7 +7,6 @@ import {UserBase} from './data/User';
 import {ApplicationType} from './enums/ApplicationType';
 import {File} from './File';
 import {PrototypePlanXMetadata} from './Metadata';
-import {PreAssessment} from './PreAssessment';
 
 /**
  * @internal
@@ -29,19 +28,19 @@ interface Application<T extends ApplicationType> {
 }
 
 /**
- * @internal
- * Some application types will have an extra property 'preAssessment' which contains the PlanX "result"
- * Ref https://docs.google.com/spreadsheets/d/1FgULPemnwuwysrYGEkReYFXz3n3T7W0nWziU00taZE4/edit?gid=0#gid=0
+ * @title PlanX pre-assessment
+ * @description The result of the application based on information provided by the user, prior to assessment by a planning officer
  */
-interface PlanXPreAssessment {
-  preAssessment: PreAssessment;
-}
+export type PlanXPreAssessment = {
+  preAssessment: {
+    value: string;
+    description: string;
+  }[];
+};
 
-/**
- * @internal
- * Types below should only include "submittable" application types only, not PlanX service-level-only prefixes like 'ldc'
- * All types are exported and acronymns are spelled out in full as they'll become the top-level toggles here https://theopensystemslab.github.io/digital-planning-data-schemas-docs/
- */
+// Types below should include "submittable" application types only, not PlanX service-level-only prefixes like 'ldc'
+// All types are exported and acronymns are spelled out in full as they'll become the top-level toggles here https://theopensystemslab.github.io/digital-planning-data-schemas-docs/
+
 export type AdvertConsent = Application<'advertConsent'>;
 
 export type AmendmentMinorMaterial = Application<'amendment.minorMaterial'>;

--- a/types/shared/MaintenanceContact.ts
+++ b/types/shared/MaintenanceContact.ts
@@ -6,10 +6,12 @@ import {ContactDetails} from './Contacts';
  * @description Contact information for the person(s) responsible for maintenance while the works are carried out
  */
 export type MaintenanceContacts = {
-  when:
-    | 'duringConstruction'
-    | 'afterConstruction'
-    | 'duringAndAfterConstruction';
-  address: Address;
-  contact: ContactDetails;
-}[];
+  maintenanceContact?: {
+    when:
+      | 'duringConstruction'
+      | 'afterConstruction'
+      | 'duringAndAfterConstruction';
+    address: Address;
+    contact: ContactDetails;
+  }[];
+};

--- a/types/shared/Ownership.ts
+++ b/types/shared/Ownership.ts
@@ -1,14 +1,30 @@
 import {Address} from './Addresses';
 import {Date} from './utils';
 
-export type OwnersInterest = 'owner' | 'lessee' | 'occupier' | 'other';
+export type OwnersInterest =
+  | 'owner'
+  | 'owner.sole'
+  | 'owner.co'
+  | 'lessee'
+  | 'occupier'
+  | 'other';
+
+/**
+ * @title Ownership interest
+ * @description Information about the applicant's relationship to the property owners
+ */
+export type OwnershipInterest = {
+  ownership: {
+    interest: OwnersInterest;
+  };
+};
 
 /**
  * @title #Ownership
  * @description Information about the ownership certificate and property owners, if different than the applicant
  */
 export interface Ownership {
-  interest?: OwnersInterest | 'owner.sole' | 'owner.co';
+  interest?: OwnersInterest;
   interestDescription?: string;
   certificate?: 'a' | 'b' | 'c' | 'd';
   /**

--- a/types/shared/SiteContact.ts
+++ b/types/shared/SiteContact.ts
@@ -4,14 +4,17 @@ import {User} from './User';
  * @title Site contact
  * @description Contact information for the site visit
  */
-export type SiteContact = {role: User['role']} | SiteContactOther;
+export type SiteContact = {
+  siteContact: {role: User['role']} | SiteContactOther;
+};
 
 /**
+ * @title Site contact other
  * @description Contact information for the site visit when the SiteContact's role is 'other'
  */
-export interface SiteContactOther {
+export type SiteContactOther = {
   role: 'other';
   name: string;
   email: string;
   phone: string;
-}
+};


### PR DESCRIPTION
Ideally, our types will be easy to write and understand as they relate to "components" or "modules" of content - like the columns of this spreadsheet https://docs.google.com/spreadsheets/d/1FgULPemnwuwysrYGEkReYFXz3n3T7W0nWziU00taZE4/edit?gid=0#gid=0

This gets us closer to that! Starting with `Applicant` data of `PrototypeApplication` first