### PR TITLE
Update pagination structure to include totalResults and totalItems fields

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -60,9 +60,13 @@ export interface Pagination {
    */
   totalPages: number;
   /**
-   * Total number of items eg 100
+   * Represents the total number of items returned by the current query
    */
-  totalItems: number;
+  totalResults: number;
+  /**
+   * Represents the total number of items in the database (unfiltered)
+   */
+  totalItems?: number;
 }
 ```
 
@@ -90,9 +94,13 @@ export interface CursorPagination {
    */
   prevCursor: string | null;
   /**
-   * Total number of items eg 100
+   * Represents the total number of items returned by the current query
    */
-  totalItems: number;
+  totalResults: number;
+  /**
+   * Represents the total number of items in the database (unfiltered)
+   */
+  totalItems?: number;
 }
 ```
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -60,13 +60,13 @@ export interface Pagination {
    */
   totalPages: number;
   /**
-   * Represents the total number of items returned by the current query
+   * Represents the total number of results returned by current query
    */
   totalResults: number;
   /**
-   * Represents the total number of items in the database (unfiltered)
+   * Represents the total number of items available in the database (#nofilter)
    */
-  totalItems?: number;
+  totalAvailableItems?: number;
 }
 ```
 
@@ -94,13 +94,13 @@ export interface CursorPagination {
    */
   prevCursor: string | null;
   /**
-   * Represents the total number of items returned by the current query
+   * Represents the total number of results returned by current query
    */
   totalResults: number;
   /**
-   * Represents the total number of items in the database (unfiltered)
+   * Represents the total number of items available in the database (#nofilter)
    */
-  totalItems?: number;
+  totalAvailableItems?: number;
 }
 ```
 

--- a/types/schemas/postSubmissionApplication/implementation/Pagination.ts
+++ b/types/schemas/postSubmissionApplication/implementation/Pagination.ts
@@ -15,9 +15,13 @@ export interface Pagination {
    */
   totalPages: number;
   /**
-   * Total number of items eg 100
+   * Represents the total number of items returned by the current query
    */
-  totalItems: number;
+  totalResults: number;
+  /**
+   * Represents the total number of items in the database (unfiltered)
+   */
+  totalItems?: number;
 }
 
 /**
@@ -37,7 +41,11 @@ export interface CursorPagination {
    */
   prevCursor: string | null;
   /**
-   * Total number of items eg 100
+   * Represents the total number of items returned by the current query
    */
-  totalItems: number;
+  totalResults: number;
+  /**
+   * Represents the total number of items in the database (unfiltered)
+   */
+  totalItems?: number;
 }

--- a/types/schemas/postSubmissionApplication/implementation/Pagination.ts
+++ b/types/schemas/postSubmissionApplication/implementation/Pagination.ts
@@ -15,13 +15,13 @@ export interface Pagination {
    */
   totalPages: number;
   /**
-   * Represents the total number of items returned by the current query
+   * Represents the total number of results returned by current query
    */
   totalResults: number;
   /**
-   * Represents the total number of items in the database (unfiltered)
+   * Represents the total number of items available in the database (#nofilter)
    */
-  totalItems?: number;
+  totalAvailableItems?: number;
 }
 
 /**
@@ -41,11 +41,11 @@ export interface CursorPagination {
    */
   prevCursor: string | null;
   /**
-   * Represents the total number of items returned by the current query
+   * Represents the total number of results returned by current query
    */
   totalResults: number;
   /**
-   * Represents the total number of items in the database (unfiltered)
+   * Represents the total number of items available in the database (#nofilter)
    */
-  totalItems?: number;
+  totalAvailableItems?: number;
 }


### PR DESCRIPTION
Updates the pagination to clarify totalResults vs totalItems. I have set totalItems to be optional since its not always feasible to calculate this value. 