### PR TITLE
feat: add `data.property.ward` across all schemas

### DIFF
--- a/examples/application/data/landDrainageConsent.ts
+++ b/examples/application/data/landDrainageConsent.ts
@@ -87,6 +87,7 @@ export const landDrainageConsent: Application = {
         postcode: 'ME1 1SW',
         singleLine: 'ROCHESTER CASTLE, CASTLE HILL, ROCHESTER, MEDWAY, ME1 1SW',
       },
+      ward: 'Rochester West & Borstal',
       localAuthorityDistrict: ['Medway'],
       region: 'South East',
       type: {

--- a/examples/application/data/lawfulDevelopmentCertificate/existing.ts
+++ b/examples/application/data/lawfulDevelopmentCertificate/existing.ts
@@ -153,6 +153,7 @@ export const lawfulDevelopmentCertificateExisting: Application = {
         town: 'GREAT MISSENDEN',
         postcode: 'HP16 0BP',
       },
+      ward: 'Great Missenden',
       boundary: {
         site: {
           type: 'Feature',

--- a/examples/application/data/lawfulDevelopmentCertificate/proposed.ts
+++ b/examples/application/data/lawfulDevelopmentCertificate/proposed.ts
@@ -71,6 +71,7 @@ export const lawfulDevelopmentCertificateProposed: Application = {
         town: 'BEACONSFIELD',
         postcode: 'HP9 2LX',
       },
+      ward: 'Beaconsfield',
       boundary: {
         site: {
           type: 'Feature',

--- a/examples/application/data/listedBuildingConsent.ts
+++ b/examples/application/data/listedBuildingConsent.ts
@@ -78,6 +78,7 @@ export const listedBuildingConsent: Application = {
         postcode: 'NW3 1PA',
         singleLine: '50, DOWNSHIRE HILL, LONDON, CAMDEN, NW3 1PA',
       },
+      ward: 'Hampstead Town',
       localAuthorityDistrict: ['Camden'],
       region: 'London',
       type: {

--- a/examples/application/data/planningPermission/fullHouseholder.ts
+++ b/examples/application/data/planningPermission/fullHouseholder.ts
@@ -105,6 +105,7 @@ export const planningPermissionFullHouseholder: Application = {
         town: 'LONDON',
         postcode: 'SW9 9RZ',
       },
+      ward: 'Brixton North',
       boundary: {
         site: {
           type: 'Feature',

--- a/examples/application/data/planningPermission/fullHouseholderInConservationArea.ts
+++ b/examples/application/data/planningPermission/fullHouseholderInConservationArea.ts
@@ -98,6 +98,7 @@ export const planningPermissionFullHouseholderInConservationArea: Application =
           town: 'LONDON',
           postcode: 'SE22 8UR',
         },
+        ward: 'Dulwich Village',
         boundary: {
           site: {
             type: 'Feature',

--- a/examples/application/data/planningPermission/major.ts
+++ b/examples/application/data/planningPermission/major.ts
@@ -84,6 +84,7 @@ export const planningPermissionMajor: Application = {
         title: 'House McHouseface Housing',
         source: 'Proposed by applicant',
       },
+      ward: 'Beaconsfield',
       localAuthorityDistrict: ['Buckinghamshire', 'South Bucks'],
       region: 'South East',
       type: {

--- a/examples/application/data/planningPermission/minor.ts
+++ b/examples/application/data/planningPermission/minor.ts
@@ -52,6 +52,7 @@ export const planningPermissionMinor: Application = {
       },
       localAuthorityDistrict: ['Aylesbury Vale', 'Buckinghamshire'],
       region: 'South East',
+      ward: 'Winslow',
       type: {
         value: 'commercial.community.hall',
         description: 'Public / Village Hall / Other Community Facility',

--- a/examples/application/data/priorApproval/buildHomes.ts
+++ b/examples/application/data/priorApproval/buildHomes.ts
@@ -40,6 +40,7 @@ export const priorApprovalBuildHomes: Application = {
         postcode: 'HP9 2LX',
         singleLine: '7, BLYTON CLOSE, BEACONSFIELD, BUCKINGHAMSHIRE, HP9 2LX',
       },
+      ward: 'Beaconsfield',
       localAuthorityDistrict: ['Buckinghamshire', 'South Bucks'],
       region: 'South East',
       type: {

--- a/examples/application/data/priorApproval/convertCommercialToHome.ts
+++ b/examples/application/data/priorApproval/convertCommercialToHome.ts
@@ -61,6 +61,7 @@ export const priorApprovalConvertCommercialToHome: Application = {
         postcode: 'SW9 0RE',
         singleLine: '87, HACKFORD ROAD, LONDON, LAMBETH, SW9 0RE',
       },
+      ward: 'Stockwell East',
       localAuthorityDistrict: ['Lambeth'],
       region: 'London',
       type: {

--- a/examples/application/data/priorApproval/extendUniversity.ts
+++ b/examples/application/data/priorApproval/extendUniversity.ts
@@ -40,6 +40,7 @@ export const priorApprovalExtendUniversity: Application = {
         postcode: 'N6 6NP',
         singleLine: '31, HIGHGATE WEST HILL, LONDON, CAMDEN, N6 6NP',
       },
+      ward: 'Highgate',
       localAuthorityDistrict: ['Camden'],
       region: 'London',
       type: {

--- a/examples/application/data/priorApproval/largerExtension.ts
+++ b/examples/application/data/priorApproval/largerExtension.ts
@@ -40,6 +40,7 @@ export const priorApprovalLargerExtension: Application = {
         postcode: 'CR8 2DL',
         singleLine: '32 ST JAMES ROAD, PURLEY, CROYDON, CR8 2DL',
       },
+      ward: 'Purley & Woodcote',
       localAuthorityDistrict: ['Croydon'],
       region: 'London',
       type: {

--- a/examples/application/data/priorApproval/solarPanels.ts
+++ b/examples/application/data/priorApproval/solarPanels.ts
@@ -42,6 +42,7 @@ export const priorApprovalSolarPanels: Application = {
         singleLine:
           'INTERNATIONAL SHAKESPEARE GLOBE CENTRE LTD, SHAKESPEARE GLOBE THEATRE, 21, NEW GLOBE WALK, LONDON, SOUTHWARK, SE1 9DT',
       },
+      ward: 'Borough & Bankside',
       localAuthorityDistrict: ['Southwark'],
       region: 'London',
       type: {

--- a/examples/application/landDrainageConsent.json
+++ b/examples/application/landDrainageConsent.json
@@ -86,6 +86,7 @@
         "postcode": "ME1 1SW",
         "singleLine": "ROCHESTER CASTLE, CASTLE HILL, ROCHESTER, MEDWAY, ME1 1SW"
       },
+      "ward": "Rochester West & Borstal",
       "localAuthorityDistrict": [
         "Medway"
       ],

--- a/examples/application/lawfulDevelopmentCertificate/existing.json
+++ b/examples/application/lawfulDevelopmentCertificate/existing.json
@@ -159,6 +159,7 @@
         "town": "GREAT MISSENDEN",
         "postcode": "HP16 0BP"
       },
+      "ward": "Great Missenden",
       "boundary": {
         "site": {
           "type": "Feature",

--- a/examples/application/lawfulDevelopmentCertificate/proposed.json
+++ b/examples/application/lawfulDevelopmentCertificate/proposed.json
@@ -67,6 +67,7 @@
         "town": "BEACONSFIELD",
         "postcode": "HP9 2LX"
       },
+      "ward": "Beaconsfield",
       "boundary": {
         "site": {
           "type": "Feature",

--- a/examples/application/listedBuildingConsent.json
+++ b/examples/application/listedBuildingConsent.json
@@ -74,6 +74,7 @@
         "postcode": "NW3 1PA",
         "singleLine": "50, DOWNSHIRE HILL, LONDON, CAMDEN, NW3 1PA"
       },
+      "ward": "Hampstead Town",
       "localAuthorityDistrict": [
         "Camden"
       ],

--- a/examples/application/planningPermission/fullHouseholder.json
+++ b/examples/application/planningPermission/fullHouseholder.json
@@ -101,6 +101,7 @@
         "town": "LONDON",
         "postcode": "SW9 9RZ"
       },
+      "ward": "Brixton North",
       "boundary": {
         "site": {
           "type": "Feature",

--- a/examples/application/planningPermission/fullHouseholderInConservationArea.json
+++ b/examples/application/planningPermission/fullHouseholderInConservationArea.json
@@ -93,6 +93,7 @@
         "town": "LONDON",
         "postcode": "SE22 8UR"
       },
+      "ward": "Dulwich Village",
       "boundary": {
         "site": {
           "type": "Feature",

--- a/examples/application/planningPermission/major.json
+++ b/examples/application/planningPermission/major.json
@@ -79,6 +79,7 @@
         "title": "House McHouseface Housing",
         "source": "Proposed by applicant"
       },
+      "ward": "Beaconsfield",
       "localAuthorityDistrict": [
         "Buckinghamshire",
         "South Bucks"

--- a/examples/application/planningPermission/minor.json
+++ b/examples/application/planningPermission/minor.json
@@ -49,6 +49,7 @@
         "Buckinghamshire"
       ],
       "region": "South East",
+      "ward": "Winslow",
       "type": {
         "value": "commercial.community.hall",
         "description": "Public / Village Hall / Other Community Facility"

--- a/examples/application/priorApproval/buildHomes.json
+++ b/examples/application/priorApproval/buildHomes.json
@@ -36,6 +36,7 @@
         "postcode": "HP9 2LX",
         "singleLine": "7, BLYTON CLOSE, BEACONSFIELD, BUCKINGHAMSHIRE, HP9 2LX"
       },
+      "ward": "Beaconsfield",
       "localAuthorityDistrict": [
         "Buckinghamshire",
         "South Bucks"

--- a/examples/application/priorApproval/convertCommercialToHome.json
+++ b/examples/application/priorApproval/convertCommercialToHome.json
@@ -57,6 +57,7 @@
         "postcode": "SW9 0RE",
         "singleLine": "87, HACKFORD ROAD, LONDON, LAMBETH, SW9 0RE"
       },
+      "ward": "Stockwell East",
       "localAuthorityDistrict": [
         "Lambeth"
       ],

--- a/examples/application/priorApproval/extendUniversity.json
+++ b/examples/application/priorApproval/extendUniversity.json
@@ -36,6 +36,7 @@
         "postcode": "N6 6NP",
         "singleLine": "31, HIGHGATE WEST HILL, LONDON, CAMDEN, N6 6NP"
       },
+      "ward": "Highgate",
       "localAuthorityDistrict": [
         "Camden"
       ],

--- a/examples/application/priorApproval/largerExtension.json
+++ b/examples/application/priorApproval/largerExtension.json
@@ -36,6 +36,7 @@
         "postcode": "CR8 2DL",
         "singleLine": "32 ST JAMES ROAD, PURLEY, CROYDON, CR8 2DL"
       },
+      "ward": "Purley & Woodcote",
       "localAuthorityDistrict": [
         "Croydon"
       ],

--- a/examples/application/priorApproval/solarPanels.json
+++ b/examples/application/priorApproval/solarPanels.json
@@ -36,6 +36,7 @@
         "postcode": "SE1 9DT",
         "singleLine": "INTERNATIONAL SHAKESPEARE GLOBE CENTRE LTD, SHAKESPEARE GLOBE THEATRE, 21, NEW GLOBE WALK, LONDON, SOUTHWARK, SE1 9DT"
       },
+      "ward": "Borough & Bankside",
       "localAuthorityDistrict": [
         "Southwark"
       ],

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-01-submission.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-01-submission.json
@@ -82,6 +82,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-02-validation-01-invalid.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-02-validation-01-invalid.json
@@ -87,6 +87,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-00-assessment-in-progress.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-00-assessment-in-progress.json
@@ -385,6 +385,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-01-council-determined.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-01-council-determined.json
@@ -390,6 +390,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-02-assessment-in-committee.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-02-assessment-in-committee.json
@@ -387,6 +387,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-03-committee-determined.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-04-assessment-03-committee-determined.json
@@ -392,6 +392,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-00-appeal-lodged.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-00-appeal-lodged.json
@@ -394,6 +394,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-01-appeal-validated.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-01-appeal-validated.json
@@ -395,6 +395,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-02-appeal-started.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-02-appeal-started.json
@@ -396,6 +396,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-03-appeal-determined.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-05-appeal-03-appeal-determined.json
@@ -398,6 +398,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-06-assessment-withdrawn.json
+++ b/examples/postSubmissionApplication/lawfulDevelopmentCertificate/proposed-06-assessment-withdrawn.json
@@ -387,6 +387,7 @@
           "town": "BEACONSFIELD",
           "postcode": "HP9 2LX"
         },
+        "ward": "Beaconsfield",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-01-submission.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-01-submission.json
@@ -108,6 +108,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-02-validation-01-invalid.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-02-validation-01-invalid.json
@@ -113,6 +113,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-03-consultation.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-03-consultation.json
@@ -413,6 +413,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-00-assessment-in-progress.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-00-assessment-in-progress.json
@@ -416,6 +416,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-01-council-determined.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-01-council-determined.json
@@ -421,6 +421,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-02-assessment-in-committee.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-02-assessment-in-committee.json
@@ -418,6 +418,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-03-committee-determined.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-04-assessment-03-committee-determined.json
@@ -423,6 +423,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-00-appeal-lodged.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-00-appeal-lodged.json
@@ -425,6 +425,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-01-appeal-validated.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-01-appeal-validated.json
@@ -426,6 +426,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-02-appeal-started.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-02-appeal-started.json
@@ -427,6 +427,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-03-appeal-determined.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-05-appeal-03-appeal-determined.json
@@ -429,6 +429,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/planningPermission/fullHouseholder-06-assessment-withdrawn.json
+++ b/examples/postSubmissionApplication/planningPermission/fullHouseholder-06-assessment-withdrawn.json
@@ -418,6 +418,7 @@
           "town": "LONDON",
           "postcode": "SW9 9RZ"
         },
+        "ward": "Brixton North",
         "boundary": {
           "site": {
             "type": "Feature",

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-01-submission.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-01-submission.json
@@ -56,6 +56,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-02-validation-01-invalid.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-02-validation-01-invalid.json
@@ -61,6 +61,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-03-consultation.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-03-consultation.json
@@ -361,6 +361,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-00-assessment-in-progress.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-00-assessment-in-progress.json
@@ -364,6 +364,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-01-council-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-01-council-determined.json
@@ -370,6 +370,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-02-assessment-in-committee.json
@@ -367,6 +367,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-03-committee-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-04-assessment-03-committee-determined.json
@@ -372,6 +372,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-00-appeal-lodged.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-00-appeal-lodged.json
@@ -374,6 +374,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-01-appeal-validated.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-01-appeal-validated.json
@@ -375,6 +375,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-02-appeal-started.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-02-appeal-started.json
@@ -376,6 +376,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-03-appeal-determined.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-05-appeal-03-appeal-determined.json
@@ -378,6 +378,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/postSubmissionApplication/priorApproval/largerExtension-06-assessment-withdrawn.json
+++ b/examples/postSubmissionApplication/priorApproval/largerExtension-06-assessment-withdrawn.json
@@ -366,6 +366,7 @@
           "Croydon"
         ],
         "region": "London",
+        "ward": "Purley & Woodcote",
         "type": "residential.dwelling.house.detached",
         "planning": {
           "sources": [

--- a/examples/preApplication/data/preApp.ts
+++ b/examples/preApplication/data/preApp.ts
@@ -43,6 +43,7 @@ export const preApplication: PreApplication = {
         postcode: 'DN9 3HW',
         singleLine: '75, MAIN STREET, AUCKLEY, DONCASTER, DN9 3HW',
       },
+      ward: 'Finningley',
       localAuthorityDistrict: ['Doncaster'],
       region: 'Yorkshire and The Humber',
       type: {

--- a/examples/preApplication/preApp.json
+++ b/examples/preApplication/preApp.json
@@ -39,6 +39,7 @@
         "postcode": "DN9 3HW",
         "singleLine": "75, MAIN STREET, AUCKLEY, DONCASTER, DN9 3HW"
       },
+      "ward": "Finningley",
       "localAuthorityDistrict": [
         "Doncaster"
       ],

--- a/examples/prototypeApplication/advertConsent.json
+++ b/examples/prototypeApplication/advertConsent.json
@@ -44,6 +44,7 @@
         "Islington"
       ],
       "region": "London",
+      "ward": "St Peter's & Canalside",
       "type": "residential.dwelling.house.terrace"
     },
     "application": {

--- a/examples/prototypeApplication/complianceConfirmation.json
+++ b/examples/prototypeApplication/complianceConfirmation.json
@@ -43,6 +43,7 @@
         "Lambeth"
       ],
       "region": "London",
+      "ward": "Clapham Town",
       "type": "residential.dwelling.house.terrace",
       "boundary": {
         "site": {

--- a/examples/prototypeApplication/data/advertConsent.ts
+++ b/examples/prototypeApplication/data/advertConsent.ts
@@ -45,6 +45,7 @@ export const advertConsentPrototype: PrototypeApplication = {
       },
       localAuthorityDistrict: ['Lambeth', 'Islington'],
       region: 'London',
+      ward: "St Peter's & Canalside",
       type: 'residential.dwelling.house.terrace',
     },
     application: {

--- a/examples/prototypeApplication/data/complianceConfirmation.ts
+++ b/examples/prototypeApplication/data/complianceConfirmation.ts
@@ -45,6 +45,7 @@ export const complianceConfirmationPrototype: PrototypeApplication = {
       },
       localAuthorityDistrict: ['Lambeth'],
       region: 'London',
+      ward: 'Clapham Town',
       type: 'residential.dwelling.house.terrace',
       boundary: {
         site: {

--- a/examples/prototypeApplication/data/hedgerowRemovalNotice.ts
+++ b/examples/prototypeApplication/data/hedgerowRemovalNotice.ts
@@ -49,6 +49,7 @@ export const hedgerowRemovalNoticePrototype: PrototypeApplication = {
       },
       localAuthorityDistrict: ['Barnet', 'Tower Hamlets'],
       region: 'London',
+      ward: 'Whitechapel',
       type: 'other.unsupported',
       planning: {
         sources: [],

--- a/examples/prototypeApplication/data/landDrainageConsent.ts
+++ b/examples/prototypeApplication/data/landDrainageConsent.ts
@@ -86,6 +86,7 @@ export const landDrainageConsentPrototype: PrototypeApplication = {
       },
       localAuthorityDistrict: ['Medway'],
       region: 'South East',
+      ward: 'Rochester West & Borstal',
       type: 'object.monument.ruin',
       planning: {
         sources: [

--- a/examples/prototypeApplication/data/lawfulDevelopmentCertificate/existing.ts
+++ b/examples/prototypeApplication/data/lawfulDevelopmentCertificate/existing.ts
@@ -268,6 +268,7 @@ export const lawfulDevelopmentCertificateExistingPrototype: PrototypeApplication
         },
         localAuthorityDistrict: ['Buckinghamshire', 'Chiltern'],
         region: 'South East',
+        ward: 'Great Missenden',
         type: 'residential.dwelling.house.detached',
       },
       proposal: {

--- a/examples/prototypeApplication/data/lawfulDevelopmentCertificate/proposed.ts
+++ b/examples/prototypeApplication/data/lawfulDevelopmentCertificate/proposed.ts
@@ -69,6 +69,7 @@ export const lawfulDevelopmentCertificateProposedPrototype: PrototypeApplication
           town: 'BEACONSFIELD',
           postcode: 'HP9 2LX',
         },
+        ward: 'Beaconsfield',
         boundary: {
           site: {
             type: 'Feature',

--- a/examples/prototypeApplication/data/listedBuildingConsent.ts
+++ b/examples/prototypeApplication/data/listedBuildingConsent.ts
@@ -79,6 +79,7 @@ export const listedBuildingConsentPrototype: PrototypeApplication = {
         postcode: 'NW3 1PA',
         singleLine: '50, DOWNSHIRE HILL, LONDON, CAMDEN, NW3 1PA',
       },
+      ward: 'Hampstead Town',
       localAuthorityDistrict: ['Camden'],
       region: 'London',
       type: 'residential.dwelling.flat',

--- a/examples/prototypeApplication/data/planningPermission/fullHouseholder.ts
+++ b/examples/prototypeApplication/data/planningPermission/fullHouseholder.ts
@@ -95,6 +95,7 @@ export const planningPermissionFullHouseholderPrototype: PrototypeApplication =
           town: 'LONDON',
           postcode: 'SW9 9RZ',
         },
+        ward: 'Brixton North',
         boundary: {
           site: {
             type: 'Feature',

--- a/examples/prototypeApplication/data/planningPermission/fullHouseholderInConservationArea.ts
+++ b/examples/prototypeApplication/data/planningPermission/fullHouseholderInConservationArea.ts
@@ -95,6 +95,7 @@ export const planningPermissionFullHouseholderInConservationAreaPrototype: Proto
           town: 'LONDON',
           postcode: 'SE22 8UR',
         },
+        ward: 'Dulwich Village',
         boundary: {
           site: {
             type: 'Feature',

--- a/examples/prototypeApplication/data/planningPermission/major.ts
+++ b/examples/prototypeApplication/data/planningPermission/major.ts
@@ -85,6 +85,7 @@ export const planningPermissionMajorPrototype: PrototypeApplication = {
         title: 'House McHouseface Housing',
         source: 'Proposed by applicant',
       },
+      ward: 'Beaconsfield',
       localAuthorityDistrict: ['Buckinghamshire', 'South Bucks'],
       region: 'South East',
       type: 'other.unsupported',

--- a/examples/prototypeApplication/data/planningPermission/minor.ts
+++ b/examples/prototypeApplication/data/planningPermission/minor.ts
@@ -50,6 +50,7 @@ export const planningPermissionMinorPrototype: PrototypeApplication = {
         singleLine:
           'WHADDON JUBILEE HALL, STOCK LANE, WHADDON, BUCKINGHAMSHIRE, MK17 0LS',
       },
+      ward: 'Winslow',
       localAuthorityDistrict: ['Aylesbury Vale', 'Buckinghamshire'],
       region: 'South East',
       type: 'commercial.community.hall',

--- a/examples/prototypeApplication/data/priorApproval/buildHomes.ts
+++ b/examples/prototypeApplication/data/priorApproval/buildHomes.ts
@@ -40,6 +40,7 @@ export const priorApprovalBuildHomesPrototype: PrototypeApplication = {
       },
       localAuthorityDistrict: ['Buckinghamshire', 'South Bucks'],
       region: 'South East',
+      ward: 'Beaconsfield',
       type: 'commercial.office',
       planning: {
         sources: [

--- a/examples/prototypeApplication/data/priorApproval/convertCommercialToHome.ts
+++ b/examples/prototypeApplication/data/priorApproval/convertCommercialToHome.ts
@@ -60,6 +60,7 @@ export const priorApprovalConvertCommercialToHomePrototype: PrototypeApplication
           postcode: 'SW9 0RE',
           singleLine: '87, HACKFORD ROAD, LONDON, LAMBETH, SW9 0RE',
         },
+        ward: 'Stockwell East',
         localAuthorityDistrict: ['Lambeth'],
         region: 'London',
         type: 'commercial.retail.shop',

--- a/examples/prototypeApplication/data/priorApproval/extendUniversity.ts
+++ b/examples/prototypeApplication/data/priorApproval/extendUniversity.ts
@@ -38,6 +38,7 @@ export const priorApprovalExtendUniversityPrototype: PrototypeApplication = {
         postcode: 'N6 6NP',
         singleLine: '31, HIGHGATE WEST HILL, LONDON, CAMDEN, N6 6NP',
       },
+      ward: 'Highgate',
       localAuthorityDistrict: ['Camden'],
       region: 'London',
       type: 'commercial.education.university',

--- a/examples/prototypeApplication/data/priorApproval/largerExtension.ts
+++ b/examples/prototypeApplication/data/priorApproval/largerExtension.ts
@@ -40,6 +40,7 @@ export const priorApprovalLargerExtensionPrototype: PrototypeApplication = {
       },
       localAuthorityDistrict: ['Croydon'],
       region: 'London',
+      ward: 'Purley & Woodcote',
       type: 'residential.dwelling.house.detached',
       planning: {
         sources: [

--- a/examples/prototypeApplication/data/priorApproval/solarPanels.ts
+++ b/examples/prototypeApplication/data/priorApproval/solarPanels.ts
@@ -40,6 +40,7 @@ export const priorApprovalSolarPanelsPrototype: PrototypeApplication = {
         singleLine:
           'INTERNATIONAL SHAKESPEARE GLOBE CENTRE LTD, SHAKESPEARE GLOBE THEATRE, 21, NEW GLOBE WALK, LONDON, SOUTHWARK, SE1 9DT',
       },
+      ward: 'Borough & Bankside',
       localAuthorityDistrict: ['Southwark'],
       region: 'London',
       type: 'commercial.leisure.entertainment',

--- a/examples/prototypeApplication/data/worksToTrees.ts
+++ b/examples/prototypeApplication/data/worksToTrees.ts
@@ -40,6 +40,7 @@ export const worksToTreesPrototype: PrototypeApplication = {
       },
       localAuthorityDistrict: ['Southwark'],
       region: 'London',
+      ward: 'Dulwich Wood',
       type: 'residential.dwelling.house.terrace',
       planning: {
         sources: [

--- a/examples/prototypeApplication/hedgerowRemovalNotice.json
+++ b/examples/prototypeApplication/hedgerowRemovalNotice.json
@@ -46,6 +46,7 @@
         "Tower Hamlets"
       ],
       "region": "London",
+      "ward": "Whitechapel",
       "type": "other.unsupported",
       "planning": {
         "sources": [],

--- a/examples/prototypeApplication/landDrainageConsent.json
+++ b/examples/prototypeApplication/landDrainageConsent.json
@@ -88,6 +88,7 @@
         "Medway"
       ],
       "region": "South East",
+      "ward": "Rochester West & Borstal",
       "type": "object.monument.ruin",
       "planning": {
         "sources": [

--- a/examples/prototypeApplication/lawfulDevelopmentCertificate/existing.json
+++ b/examples/prototypeApplication/lawfulDevelopmentCertificate/existing.json
@@ -358,6 +358,7 @@
         "Chiltern"
       ],
       "region": "South East",
+      "ward": "Great Missenden",
       "type": "residential.dwelling.house.detached"
     },
     "proposal": {

--- a/examples/prototypeApplication/lawfulDevelopmentCertificate/proposed.json
+++ b/examples/prototypeApplication/lawfulDevelopmentCertificate/proposed.json
@@ -64,6 +64,7 @@
         "town": "BEACONSFIELD",
         "postcode": "HP9 2LX"
       },
+      "ward": "Beaconsfield",
       "boundary": {
         "site": {
           "type": "Feature",

--- a/examples/prototypeApplication/listedBuildingConsent.json
+++ b/examples/prototypeApplication/listedBuildingConsent.json
@@ -75,6 +75,7 @@
         "postcode": "NW3 1PA",
         "singleLine": "50, DOWNSHIRE HILL, LONDON, CAMDEN, NW3 1PA"
       },
+      "ward": "Hampstead Town",
       "localAuthorityDistrict": [
         "Camden"
       ],

--- a/examples/prototypeApplication/planningPermission/fullHouseholder.json
+++ b/examples/prototypeApplication/planningPermission/fullHouseholder.json
@@ -90,6 +90,7 @@
         "town": "LONDON",
         "postcode": "SW9 9RZ"
       },
+      "ward": "Brixton North",
       "boundary": {
         "site": {
           "type": "Feature",

--- a/examples/prototypeApplication/planningPermission/fullHouseholderInConservationArea.json
+++ b/examples/prototypeApplication/planningPermission/fullHouseholderInConservationArea.json
@@ -90,6 +90,7 @@
         "town": "LONDON",
         "postcode": "SE22 8UR"
       },
+      "ward": "Dulwich Village",
       "boundary": {
         "site": {
           "type": "Feature",

--- a/examples/prototypeApplication/planningPermission/major.json
+++ b/examples/prototypeApplication/planningPermission/major.json
@@ -80,6 +80,7 @@
         "title": "House McHouseface Housing",
         "source": "Proposed by applicant"
       },
+      "ward": "Beaconsfield",
       "localAuthorityDistrict": [
         "Buckinghamshire",
         "South Bucks"

--- a/examples/prototypeApplication/planningPermission/minor.json
+++ b/examples/prototypeApplication/planningPermission/minor.json
@@ -45,6 +45,7 @@
         "postcode": "MK17 0LS",
         "singleLine": "WHADDON JUBILEE HALL, STOCK LANE, WHADDON, BUCKINGHAMSHIRE, MK17 0LS"
       },
+      "ward": "Winslow",
       "localAuthorityDistrict": [
         "Aylesbury Vale",
         "Buckinghamshire"

--- a/examples/prototypeApplication/priorApproval/buildHomes.json
+++ b/examples/prototypeApplication/priorApproval/buildHomes.json
@@ -39,6 +39,7 @@
         "South Bucks"
       ],
       "region": "South East",
+      "ward": "Beaconsfield",
       "type": "commercial.office",
       "planning": {
         "sources": [

--- a/examples/prototypeApplication/priorApproval/convertCommercialToHome.json
+++ b/examples/prototypeApplication/priorApproval/convertCommercialToHome.json
@@ -55,6 +55,7 @@
         "postcode": "SW9 0RE",
         "singleLine": "87, HACKFORD ROAD, LONDON, LAMBETH, SW9 0RE"
       },
+      "ward": "Stockwell East",
       "localAuthorityDistrict": [
         "Lambeth"
       ],

--- a/examples/prototypeApplication/priorApproval/extendUniversity.json
+++ b/examples/prototypeApplication/priorApproval/extendUniversity.json
@@ -34,6 +34,7 @@
         "postcode": "N6 6NP",
         "singleLine": "31, HIGHGATE WEST HILL, LONDON, CAMDEN, N6 6NP"
       },
+      "ward": "Highgate",
       "localAuthorityDistrict": [
         "Camden"
       ],

--- a/examples/prototypeApplication/priorApproval/largerExtension.json
+++ b/examples/prototypeApplication/priorApproval/largerExtension.json
@@ -38,6 +38,7 @@
         "Croydon"
       ],
       "region": "London",
+      "ward": "Purley & Woodcote",
       "type": "residential.dwelling.house.detached",
       "planning": {
         "sources": [

--- a/examples/prototypeApplication/priorApproval/solarPanels.json
+++ b/examples/prototypeApplication/priorApproval/solarPanels.json
@@ -34,6 +34,7 @@
         "postcode": "SE1 9DT",
         "singleLine": "INTERNATIONAL SHAKESPEARE GLOBE CENTRE LTD, SHAKESPEARE GLOBE THEATRE, 21, NEW GLOBE WALK, LONDON, SOUTHWARK, SE1 9DT"
       },
+      "ward": "Borough & Bankside",
       "localAuthorityDistrict": [
         "Southwark"
       ],

--- a/examples/prototypeApplication/worksToTrees.json
+++ b/examples/prototypeApplication/worksToTrees.json
@@ -38,6 +38,7 @@
         "Southwark"
       ],
       "region": "London",
+      "ward": "Dulwich Wood",
       "type": "residential.dwelling.house.terrace",
       "planning": {
         "sources": [

--- a/schemas/application.json
+++ b/schemas/application.json
@@ -6791,7 +6791,8 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
@@ -6918,8 +6919,8 @@
           "type": "object"
         },
         "region": {
-          "const": "London",
-          "type": "string"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "socialLandlord": {
           "anyOf": [
@@ -7022,13 +7023,18 @@
             "description"
           ],
           "type": "object"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
       "required": [
         "address",
         "localAuthorityDistrict",
         "region",
-        "type"
+        "type",
+        "ward"
       ],
       "type": "object"
     },
@@ -30200,7 +30206,8 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
@@ -30288,7 +30295,8 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/Region"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "trees": {
           "additionalProperties": false,
@@ -30337,13 +30345,18 @@
             "description"
           ],
           "type": "object"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
       "required": [
         "address",
-        "region",
         "localAuthorityDistrict",
-        "type"
+        "region",
+        "type",
+        "ward"
       ],
       "type": "object"
     },

--- a/schemas/postSubmissionApplication.json
+++ b/schemas/postSubmissionApplication.json
@@ -3532,14 +3532,15 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
-          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
         },
         "localAuthorityDistrict": {
-          "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+          "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
@@ -3603,17 +3604,23 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/Region"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
       "required": [
         "address",
-        "region",
         "localAuthorityDistrict",
-        "type"
+        "region",
+        "type",
+        "ward"
       ],
       "type": "object"
     },
@@ -6649,14 +6656,15 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
-          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
         },
         "localAuthorityDistrict": {
-          "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+          "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
@@ -6723,8 +6731,8 @@
           "type": "object"
         },
         "region": {
-          "const": "London",
-          "type": "string"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "titleNumber": {
           "additionalProperties": false,
@@ -6747,13 +6755,18 @@
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
       "required": [
         "address",
         "localAuthorityDistrict",
         "region",
-        "type"
+        "type",
+        "ward"
       ],
       "type": "object"
     },
@@ -9266,14 +9279,15 @@
                 {
                   "$ref": "#/definitions/OSAddress"
                 }
-              ]
+              ],
+              "description": "The property address"
             },
             "boundary": {
               "$ref": "#/definitions/GeoBoundary",
-              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
             },
             "localAuthorityDistrict": {
-              "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+              "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
               "items": {
                 "type": "string"
               },
@@ -9340,7 +9354,8 @@
               "type": "object"
             },
             "region": {
-              "$ref": "#/definitions/Region"
+              "$ref": "#/definitions/Region",
+              "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
             },
             "type": {
               "$ref": "#/definitions/PropertyType"
@@ -9356,13 +9371,18 @@
                 "description"
               ],
               "type": "object"
+            },
+            "ward": {
+              "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+              "type": "string"
             }
           },
           "required": [
             "address",
             "localAuthorityDistrict",
             "region",
-            "type"
+            "type",
+            "ward"
           ],
           "type": "object"
         },
@@ -9399,14 +9419,15 @@
                 {
                   "$ref": "#/definitions/OSAddress"
                 }
-              ]
+              ],
+              "description": "The property address"
             },
             "boundary": {
               "$ref": "#/definitions/GeoBoundary",
-              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
             },
             "localAuthorityDistrict": {
-              "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+              "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
               "items": {
                 "type": "string"
               },
@@ -9476,8 +9497,8 @@
               "type": "object"
             },
             "region": {
-              "const": "London",
-              "type": "string"
+              "$ref": "#/definitions/Region",
+              "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
             },
             "titleNumber": {
               "additionalProperties": false,
@@ -9512,13 +9533,18 @@
                 "description"
               ],
               "type": "object"
+            },
+            "ward": {
+              "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+              "type": "string"
             }
           },
           "required": [
             "address",
             "localAuthorityDistrict",
             "region",
-            "type"
+            "type",
+            "ward"
           ],
           "type": "object"
         }

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -6993,7 +6993,8 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
@@ -7030,17 +7031,23 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/Region"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
       "required": [
         "address",
-        "region",
         "localAuthorityDistrict",
-        "type"
+        "region",
+        "type",
+        "ward"
       ],
       "type": "object"
     },

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -3360,14 +3360,15 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
-          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
         },
         "localAuthorityDistrict": {
-          "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+          "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
@@ -3431,17 +3432,23 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/Region"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
       "required": [
         "address",
-        "region",
         "localAuthorityDistrict",
-        "type"
+        "region",
+        "type",
+        "ward"
       ],
       "type": "object"
     },
@@ -6477,14 +6484,15 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
-          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
         },
         "localAuthorityDistrict": {
-          "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+          "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
@@ -6551,8 +6559,8 @@
           "type": "object"
         },
         "region": {
-          "const": "London",
-          "type": "string"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "titleNumber": {
           "additionalProperties": false,
@@ -6575,13 +6583,18 @@
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
       "required": [
         "address",
         "localAuthorityDistrict",
         "region",
-        "type"
+        "type",
+        "ward"
       ],
       "type": "object"
     },
@@ -9094,14 +9107,15 @@
                 {
                   "$ref": "#/definitions/OSAddress"
                 }
-              ]
+              ],
+              "description": "The property address"
             },
             "boundary": {
               "$ref": "#/definitions/GeoBoundary",
-              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
             },
             "localAuthorityDistrict": {
-              "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+              "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
               "items": {
                 "type": "string"
               },
@@ -9168,7 +9182,8 @@
               "type": "object"
             },
             "region": {
-              "$ref": "#/definitions/Region"
+              "$ref": "#/definitions/Region",
+              "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
             },
             "type": {
               "$ref": "#/definitions/PropertyType"
@@ -9184,13 +9199,18 @@
                 "description"
               ],
               "type": "object"
+            },
+            "ward": {
+              "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+              "type": "string"
             }
           },
           "required": [
             "address",
             "localAuthorityDistrict",
             "region",
-            "type"
+            "type",
+            "ward"
           ],
           "type": "object"
         },
@@ -9227,14 +9247,15 @@
                 {
                   "$ref": "#/definitions/OSAddress"
                 }
-              ]
+              ],
+              "description": "The property address"
             },
             "boundary": {
               "$ref": "#/definitions/GeoBoundary",
-              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+              "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
             },
             "localAuthorityDistrict": {
-              "description": "Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+              "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
               "items": {
                 "type": "string"
               },
@@ -9304,8 +9325,8 @@
               "type": "object"
             },
             "region": {
-              "const": "London",
-              "type": "string"
+              "$ref": "#/definitions/Region",
+              "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
             },
             "titleNumber": {
               "additionalProperties": false,
@@ -9340,13 +9361,18 @@
                 "description"
               ],
               "type": "object"
+            },
+            "ward": {
+              "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+              "type": "string"
             }
           },
           "required": [
             "address",
             "localAuthorityDistrict",
             "region",
-            "type"
+            "type",
+            "ward"
           ],
           "type": "object"
         }

--- a/types/schemas/application/data/Property.ts
+++ b/types/schemas/application/data/Property.ts
@@ -1,4 +1,3 @@
-import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
 import {
   PlanningConstraint,
   PlanningDesignation,
@@ -6,9 +5,9 @@ import {
 import {Materials} from '../../../shared/Materials';
 import {ExistingLondonParking} from '../../../shared/Parking';
 import {Region} from '../../../shared/Regions';
+import {Site} from '../../../shared/Sites';
 import {Date, URL} from '../../../shared/utils';
 import {PropertyType} from '../enums/PropertyTypes';
-import {GeoBoundary} from './../../../shared/Boundaries';
 import {ResidentialUnits} from './shared';
 
 /**
@@ -21,18 +20,8 @@ export type Property = UKProperty | LondonProperty;
  * @id #UKProperty
  * @description Property details for sites anywhere in the UK
  */
-export interface UKProperty {
-  address: ProposedAddress | OSAddress;
-  region: Region;
-  /**
-   * @description Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
-   */
-  localAuthorityDistrict: string[];
+export type UKProperty = Site & {
   type: PropertyType;
-  /**
-   * @description HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary
-   */
-  boundary?: GeoBoundary;
   /**
    * @description Planning constraints and policies that intersect with this site and may impact or restrict development
    */
@@ -77,13 +66,13 @@ export interface UKProperty {
     adjacent: boolean;
   };
   units?: ResidentialUnits;
-}
+};
 
 /**
  * @id #LondonProperty
  * @description Property details for sites within the Greater London Authority (GLA) area
  */
-export interface LondonProperty extends UKProperty {
+export type LondonProperty = UKProperty & {
   region: Extract<Region, 'London'>;
   titleNumber?: {
     known: 'Yes' | 'No';
@@ -117,4 +106,4 @@ export interface LondonProperty extends UKProperty {
     status: 'occupied' | 'partVacant' | 'vacant';
   };
   parking?: ExistingLondonParking;
-}
+};

--- a/types/schemas/preApplication/data/Property.ts
+++ b/types/schemas/preApplication/data/Property.ts
@@ -1,22 +1,10 @@
-import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
 import {PlanningDesignation} from '../../../shared/Constraints';
-import {Region} from '../../../shared/Regions';
+import {Site} from '../../../shared/Sites';
 import {URL} from '../../../shared/utils';
 import {PropertyType} from '../../application/enums/PropertyTypes';
-import {GeoBoundary} from './../../../shared/Boundaries';
 
-export interface Property {
-  address: ProposedAddress | OSAddress;
-  region: Region;
-  /**
-   * @description Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
-   */
-  localAuthorityDistrict: string[];
+export type Property = Site & {
   type: PropertyType;
-  /**
-   * @description HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary
-   */
-  boundary?: GeoBoundary;
   /**
    * @description Planning constraints and policies that intersect with this site and may impact or restrict development
    */
@@ -27,4 +15,4 @@ export interface Property {
     sources: URL[];
     designations?: PlanningDesignation[];
   };
-}
+};

--- a/types/schemas/prototypeApplication/data/Property.ts
+++ b/types/schemas/prototypeApplication/data/Property.ts
@@ -1,6 +1,7 @@
 import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
 import {GeoBoundary} from './../../../shared/Boundaries';
 import {Materials} from '../../../shared/Materials';
+import {Site} from '../../../shared/Sites';
 import {Region} from '../../../shared/Regions';
 import {URL} from '../../../shared/utils';
 import {
@@ -16,18 +17,8 @@ export type PropertyBase = EnglandProperty | LondonProperty;
 /**
  * @description Property details for sites anywhere in England
  */
-export interface EnglandProperty {
-  address: ProposedAddress | OSAddress;
-  region: Region;
-  /**
-   * @description Current and historic England Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
-   */
-  localAuthorityDistrict: string[];
+export type EnglandProperty = Site & {
   type: PropertyType;
-  /**
-   * @description HM Land Registry Index polygon for this property, commonly referred to as the blue-line or title boundary, sourced from planning.data.gov.uk/dataset/title-boundary
-   */
-  boundary?: GeoBoundary;
   /**
    * @description Planning constraints and policies that intersect with this site and may impact or restrict development
    */
@@ -44,12 +35,12 @@ export interface EnglandProperty {
       neighbourhood: PlanningConstraint[];
     };
   };
-}
+};
 
 /**
  * @description Property details for sites within the Greater London Authority (GLA) area
  */
-export interface LondonProperty extends EnglandProperty {
+export type LondonProperty = EnglandProperty & {
   region: Extract<Region, 'London'>;
   titleNumber?: {
     known: 'Yes' | 'No';
@@ -67,7 +58,7 @@ export interface LondonProperty extends EnglandProperty {
     number?: string;
   };
   parking?: ExistingLondonParking;
-}
+};
 
 export type PPProperty = PropertyBase & {
   materials?: Materials;

--- a/types/schemas/prototypeApplication/data/Property.ts
+++ b/types/schemas/prototypeApplication/data/Property.ts
@@ -1,16 +1,14 @@
-import {OSAddress, ProposedAddress} from '../../../shared/Addresses';
-import {GeoBoundary} from './../../../shared/Boundaries';
-import {Materials} from '../../../shared/Materials';
-import {Site} from '../../../shared/Sites';
-import {Region} from '../../../shared/Regions';
-import {URL} from '../../../shared/utils';
 import {
   PlanningConstraint,
   PlanningDesignation,
 } from '../../../shared/Constraints';
-import {PropertyType} from '../enums/PropertyTypes';
+import {Materials} from '../../../shared/Materials';
 import {ExistingLondonParking} from '../../../shared/Parking';
+import {Region} from '../../../shared/Regions';
+import {Site} from '../../../shared/Sites';
+import {URL} from '../../../shared/utils';
 import {ApplicationType} from '../enums/ApplicationType';
+import {PropertyType} from '../enums/PropertyTypes';
 
 export type PropertyBase = EnglandProperty | LondonProperty;
 

--- a/types/shared/Sites.ts
+++ b/types/shared/Sites.ts
@@ -1,0 +1,31 @@
+import {OSAddress, ProposedAddress} from './Addresses';
+import {GeoBoundary} from './Boundaries';
+import {Region} from './Regions';
+
+/**
+ * @description Details about the property as the site exists now
+ */
+export type Site = {
+  /**
+   * @description The property address
+   */
+  address: ProposedAddress | OSAddress;
+  /**
+   * @description Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
+   */
+  localAuthorityDistrict: string[];
+  /**
+   * @description Name of the ward sourced from planning.data.gov.uk/dataset/ward
+   */
+  ward: string;
+  /**
+   * @description Name of the region sourced from planning.data.gov.uk/dataset/region; "London" is a proxy for the Greater London Authority
+   */
+  region: Region;
+  /**
+   * @description HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary
+   */
+  boundary?: GeoBoundary;
+};
+
+// TODO eventually add 'type' to shared def above once enums are standardised (eg matching all fields set by PlanX's FindProperty component)


### PR DESCRIPTION
Planning Data now publishes [wards](https://www.planning.data.gov.uk/dataset/ward) which PlanX automatically joins to the propery address info. The schema can now pass along the ward name for given property.

**Changes:**
- Extracts common required `data.property` fields including new `ward` property out into a shared type `Site` so we don't have to duplicate annotations, descriptions etc
- Since `ward` is required, added the correct value across all example payloads