### PR TITLE
Postsubmission: Small name changes for clarity

### DIFF
--- a/schemas/postSubmissionApplication.json
+++ b/schemas/postSubmissionApplication.json
@@ -2657,73 +2657,6 @@
       ],
       "type": "object"
     },
-    "CommentSentiment": {
-      "$id": "#CommentSentiment",
-      "anyOf": [
-        {
-          "const": "objection",
-          "description": "Objection comment",
-          "type": "string"
-        },
-        {
-          "const": "neutral",
-          "description": "Neutral comment",
-          "type": "string"
-        },
-        {
-          "const": "supportive",
-          "description": "Supportive comment",
-          "type": "string"
-        }
-      ],
-      "description": "Types of comments"
-    },
-    "CommentTopic": {
-      "$id": "#CommentTopic",
-      "anyOf": [
-        {
-          "const": "design",
-          "description": "Comment on the design, size or height of new buildings or extensions",
-          "type": "string"
-        },
-        {
-          "const": "use",
-          "description": "Comment on the use and function of the proposed development",
-          "type": "string"
-        },
-        {
-          "const": "light",
-          "description": "Comment on impacts on natural light",
-          "type": "string"
-        },
-        {
-          "const": "privacy",
-          "description": "Comment on impacts to the privacy of neighbours",
-          "type": "string"
-        },
-        {
-          "const": "access",
-          "description": "Comment on impacts on disabled persons' access",
-          "type": "string"
-        },
-        {
-          "const": "noise",
-          "description": "Comment on any noise from new uses",
-          "type": "string"
-        },
-        {
-          "const": "traffic",
-          "description": "Comment on impacts to traffic, parking or road safety",
-          "type": "string"
-        },
-        {
-          "const": "other",
-          "description": "Comment on other things",
-          "type": "string"
-        }
-      ],
-      "description": "Types of comments"
-    },
     "CommunityInfrastructureLevy": {
       "anyOf": [
         {
@@ -42785,7 +42718,7 @@
           "description": "Further information about the comment"
         },
         "sentiment": {
-          "$ref": "#/definitions/CommentSentiment",
+          "$ref": "#/definitions/PublicCommentSentiment",
           "description": "What is the sentiment of the comment?"
         }
       },
@@ -42822,6 +42755,27 @@
         "name"
       ],
       "type": "object"
+    },
+    "PublicCommentSentiment": {
+      "$id": "#PublicCommentSentiment",
+      "anyOf": [
+        {
+          "const": "objection",
+          "description": "Objection comment",
+          "type": "string"
+        },
+        {
+          "const": "neutral",
+          "description": "Neutral comment",
+          "type": "string"
+        },
+        {
+          "const": "supportive",
+          "description": "Supportive comment",
+          "type": "string"
+        }
+      ],
+      "description": "Types of comments"
     },
     "PublicCommentSummary": {
       "$id": "#PublicCommentsSummary",
@@ -42860,6 +42814,52 @@
         "totalComments"
       ],
       "type": "object"
+    },
+    "PublicCommentTopic": {
+      "$id": "#PublicCommentTopic",
+      "anyOf": [
+        {
+          "const": "design",
+          "description": "Comment on the design, size or height of new buildings or extensions",
+          "type": "string"
+        },
+        {
+          "const": "use",
+          "description": "Comment on the use and function of the proposed development",
+          "type": "string"
+        },
+        {
+          "const": "light",
+          "description": "Comment on impacts on natural light",
+          "type": "string"
+        },
+        {
+          "const": "privacy",
+          "description": "Comment on impacts to the privacy of neighbours",
+          "type": "string"
+        },
+        {
+          "const": "access",
+          "description": "Comment on impacts on disabled persons' access",
+          "type": "string"
+        },
+        {
+          "const": "noise",
+          "description": "Comment on any noise from new uses",
+          "type": "string"
+        },
+        {
+          "const": "traffic",
+          "description": "Comment on impacts to traffic, parking or road safety",
+          "type": "string"
+        },
+        {
+          "const": "other",
+          "description": "Comment on other things",
+          "type": "string"
+        }
+      ],
+      "description": "Types of comments"
     },
     "PublicComments": {
       "$id": "#PublicComments",
@@ -43324,7 +43324,7 @@
           "type": "string"
         },
         "topic": {
-          "$ref": "#/definitions/CommentTopic",
+          "$ref": "#/definitions/PublicCommentTopic",
           "description": "The topic of the comment"
         }
       },

--- a/schemas/postSubmissionPublishedApplication.json
+++ b/schemas/postSubmissionPublishedApplication.json
@@ -2634,73 +2634,6 @@
       ],
       "type": "object"
     },
-    "CommentSentiment": {
-      "$id": "#CommentSentiment",
-      "anyOf": [
-        {
-          "const": "objection",
-          "description": "Objection comment",
-          "type": "string"
-        },
-        {
-          "const": "neutral",
-          "description": "Neutral comment",
-          "type": "string"
-        },
-        {
-          "const": "supportive",
-          "description": "Supportive comment",
-          "type": "string"
-        }
-      ],
-      "description": "Types of comments"
-    },
-    "CommentTopic": {
-      "$id": "#CommentTopic",
-      "anyOf": [
-        {
-          "const": "design",
-          "description": "Comment on the design, size or height of new buildings or extensions",
-          "type": "string"
-        },
-        {
-          "const": "use",
-          "description": "Comment on the use and function of the proposed development",
-          "type": "string"
-        },
-        {
-          "const": "light",
-          "description": "Comment on impacts on natural light",
-          "type": "string"
-        },
-        {
-          "const": "privacy",
-          "description": "Comment on impacts to the privacy of neighbours",
-          "type": "string"
-        },
-        {
-          "const": "access",
-          "description": "Comment on impacts on disabled persons' access",
-          "type": "string"
-        },
-        {
-          "const": "noise",
-          "description": "Comment on any noise from new uses",
-          "type": "string"
-        },
-        {
-          "const": "traffic",
-          "description": "Comment on impacts to traffic, parking or road safety",
-          "type": "string"
-        },
-        {
-          "const": "other",
-          "description": "Comment on other things",
-          "type": "string"
-        }
-      ],
-      "description": "Types of comments"
-    },
     "CommunityInfrastructureLevy": {
       "anyOf": [
         {
@@ -42788,7 +42721,7 @@
           "type": "object"
         },
         "sentiment": {
-          "$ref": "#/definitions/CommentSentiment",
+          "$ref": "#/definitions/PublicCommentSentiment",
           "description": "What is the sentiment of the comment?"
         }
       },
@@ -42800,6 +42733,27 @@
         "sentiment"
       ],
       "type": "object"
+    },
+    "PublicCommentSentiment": {
+      "$id": "#PublicCommentSentiment",
+      "anyOf": [
+        {
+          "const": "objection",
+          "description": "Objection comment",
+          "type": "string"
+        },
+        {
+          "const": "neutral",
+          "description": "Neutral comment",
+          "type": "string"
+        },
+        {
+          "const": "supportive",
+          "description": "Supportive comment",
+          "type": "string"
+        }
+      ],
+      "description": "Types of comments"
     },
     "PublicCommentSummary": {
       "$id": "#PublicCommentsSummary",
@@ -42838,6 +42792,52 @@
         "totalComments"
       ],
       "type": "object"
+    },
+    "PublicCommentTopic": {
+      "$id": "#PublicCommentTopic",
+      "anyOf": [
+        {
+          "const": "design",
+          "description": "Comment on the design, size or height of new buildings or extensions",
+          "type": "string"
+        },
+        {
+          "const": "use",
+          "description": "Comment on the use and function of the proposed development",
+          "type": "string"
+        },
+        {
+          "const": "light",
+          "description": "Comment on impacts on natural light",
+          "type": "string"
+        },
+        {
+          "const": "privacy",
+          "description": "Comment on impacts to the privacy of neighbours",
+          "type": "string"
+        },
+        {
+          "const": "access",
+          "description": "Comment on impacts on disabled persons' access",
+          "type": "string"
+        },
+        {
+          "const": "noise",
+          "description": "Comment on any noise from new uses",
+          "type": "string"
+        },
+        {
+          "const": "traffic",
+          "description": "Comment on impacts to traffic, parking or road safety",
+          "type": "string"
+        },
+        {
+          "const": "other",
+          "description": "Comment on other things",
+          "type": "string"
+        }
+      ],
+      "description": "Types of comments"
     },
     "PublicCommentsRedacted": {
       "$id": "#PublicCommentsRedacted",
@@ -43313,7 +43313,7 @@
           "type": "string"
         },
         "topic": {
-          "$ref": "#/definitions/CommentTopic",
+          "$ref": "#/definitions/PublicCommentTopic",
           "description": "The topic of the comment"
         }
       },

--- a/types/schemas/postSubmissionApplication/README.md
+++ b/types/schemas/postSubmissionApplication/README.md
@@ -367,7 +367,7 @@ undetermined:::status
 submission --> validation
 validation --> consultation
 consultation --> assessment
-assessment -.-> appeal
+assessment -.-> |After determination made or if assessment expiryDate passed|appeal
 appeal -.-> highCourtAppeal
 
 
@@ -428,7 +428,7 @@ flowchart TD
   submission --> validation
   validation --> consultation
   consultation --> assessment
-  assessment -.-> appeal
+  assessment -.-> |After determination made or if assessment expiryDate passed|appeal
   appeal -.-> highCourtAppeal
 
 

--- a/types/schemas/postSubmissionApplication/data/Assessment.ts
+++ b/types/schemas/postSubmissionApplication/data/Assessment.ts
@@ -11,7 +11,7 @@ import {AssessmentDecision} from '../enums/AssessmentDecision';
  */
 export type PostSubmissionAssessment = AssessmentBase &
   AssessmentDecisionSection &
-  AssessmentCommittee;
+  AssessmentCommitteeDecision;
 
 /**
  * @description Base type for all assessments
@@ -50,10 +50,10 @@ type AssessmentDecisionSection = {
 };
 
 /**
- * @description AssessmentCommittee
+ * @description AssessmentCommitteeDecision
  * When a decision is made by a committee in a LPA
  */
-type AssessmentCommittee = {
+type AssessmentCommitteeDecision = {
   /**
    * This is the recommendation made by planning officer(s) to the committee
    * This is an alternative to a decision - either planningOfficerDecision or planningOfficerRecommendation can be set not both

--- a/types/schemas/postSubmissionApplication/data/CommentSummary.ts
+++ b/types/schemas/postSubmissionApplication/data/CommentSummary.ts
@@ -3,7 +3,7 @@
  */
 
 import {
-  CommentSentiment,
+  PublicCommentSentiment,
   SpecialistCommentSentiment,
 } from '../enums/CommentSentiment';
 
@@ -21,7 +21,7 @@ export interface PublicCommentSummary extends CommentSummaryBase {
   /**
    * Comment number broken down by sentiment count
    */
-  sentiment: Record<CommentSentiment, number>;
+  sentiment: Record<PublicCommentSentiment, number>;
 }
 
 /**

--- a/types/schemas/postSubmissionApplication/data/PublicComment.ts
+++ b/types/schemas/postSubmissionApplication/data/PublicComment.ts
@@ -1,5 +1,5 @@
-import {CommentSentiment} from '../enums/CommentSentiment';
-import {CommentTopic} from '../enums/CommentTopic';
+import {PublicCommentSentiment} from '../enums/CommentSentiment';
+import {PublicCommentTopic} from '../enums/CommentTopic';
 import {CommentMetaData} from './Comment';
 
 /**
@@ -13,7 +13,7 @@ interface PublicCommentBase {
   /**
    * What is the sentiment of the comment?
    */
-  sentiment: CommentSentiment;
+  sentiment: PublicCommentSentiment;
   /**
    * The author of the comment
    */
@@ -78,7 +78,7 @@ export interface TopicAndComments {
   /**
    * The topic of the comment
    */
-  topic: CommentTopic;
+  topic: PublicCommentTopic;
   /**
    * What question was asked
    * Follows convention of Responses

--- a/types/schemas/postSubmissionApplication/enums/CommentSentiment.ts
+++ b/types/schemas/postSubmissionApplication/enums/CommentSentiment.ts
@@ -14,10 +14,10 @@ type Neutral = 'neutral';
 type Supportive = 'supportive';
 
 /**
- * @id #CommentSentiment
+ * @id #PublicCommentSentiment
  * @description Types of comments
  */
-export type CommentSentiment = Objection | Neutral | Supportive;
+export type PublicCommentSentiment = Objection | Neutral | Supportive;
 
 /**
  * @description Approved

--- a/types/schemas/postSubmissionApplication/enums/CommentTopic.ts
+++ b/types/schemas/postSubmissionApplication/enums/CommentTopic.ts
@@ -39,10 +39,10 @@ type Traffic = 'traffic';
 type Other = 'other';
 
 /**
- * @id #CommentTopic
+ * @id #PublicCommentTopic
  * @description Types of comments
  */
-export type CommentTopic =
+export type PublicCommentTopic =
   | Design
   | Use
   | Light


### PR DESCRIPTION
Just changing some names for better clarity of what they represent, also a small readme change noting that appeals can happen after determination is made or if assessment expiryDate passed.

- `CommentSentiment` > `PublicCommentSentiment`
- `CommentTopic` > `PublicCommentTopic`
- `AssessmentCommittee` > `AssessmentCommitteeDecision`