### PR TITLE
Add two new file types decisionNotice and applicationSubmission

### DIFF
--- a/schemas/postSubmissionApplication.json
+++ b/schemas/postSubmissionApplication.json
@@ -42145,6 +42145,11 @@
           "type": "string"
         },
         {
+          "const": "applicationSubmission",
+          "description": "Application submission",
+          "type": "string"
+        },
+        {
           "const": "arboriculturistReport",
           "description": "Arboriculturist report",
           "type": "string"
@@ -42202,6 +42207,11 @@
         {
           "const": "crimePreventionStrategy",
           "description": "Crime prevention strategy",
+          "type": "string"
+        },
+        {
+          "const": "decisionNotice",
+          "description": "Decision notice",
           "type": "string"
         },
         {

--- a/schemas/postSubmissionPublishedApplication.json
+++ b/schemas/postSubmissionPublishedApplication.json
@@ -42122,6 +42122,11 @@
           "type": "string"
         },
         {
+          "const": "applicationSubmission",
+          "description": "Application submission",
+          "type": "string"
+        },
+        {
           "const": "arboriculturistReport",
           "description": "Arboriculturist report",
           "type": "string"
@@ -42179,6 +42184,11 @@
         {
           "const": "crimePreventionStrategy",
           "description": "Crime prevention strategy",
+          "type": "string"
+        },
+        {
+          "const": "decisionNotice",
+          "description": "Decision notice",
           "type": "string"
         },
         {

--- a/schemas/prototypeApplication.json
+++ b/schemas/prototypeApplication.json
@@ -21939,6 +21939,11 @@
           "type": "string"
         },
         {
+          "const": "applicationSubmission",
+          "description": "Application submission",
+          "type": "string"
+        },
+        {
           "const": "arboriculturistReport",
           "description": "Arboriculturist report",
           "type": "string"
@@ -21996,6 +22001,11 @@
         {
           "const": "crimePreventionStrategy",
           "description": "Crime prevention strategy",
+          "type": "string"
+        },
+        {
+          "const": "decisionNotice",
+          "description": "Decision notice",
           "type": "string"
         },
         {

--- a/types/schemas/prototypeApplication/enums/FileType.ts
+++ b/types/schemas/prototypeApplication/enums/FileType.ts
@@ -14,6 +14,11 @@ type AdvertsDrawings = 'advertsDrawings';
 type AffordableHousingStatement = 'affordableHousingStatement';
 
 /**
+ * @description Application submission
+ */
+type ApplicationSubmission = 'applicationSubmission';
+
+/**
  * @description Arboriculturist report
  */
 type ArboriculturistReport = 'arboriculturistReport';
@@ -72,6 +77,11 @@ type CouncilTaxBill = 'councilTaxBill';
  * @description Crime prevention strategy
  */
 type CrimePreventionStrategy = 'crimePreventionStrategy';
+
+/**
+ * @description Decision notice
+ */
+type DecisionNotice = 'decisionNotice';
 
 /**
  * @description Design and Access Statement
@@ -519,6 +529,7 @@ export type PrototypeFileType =
   | AccessRoadsRightsOfWayDetails
   | AdvertsDrawings
   | AffordableHousingStatement
+  | ApplicationSubmission
   | ArboriculturistReport
   | BankStatement
   | BasementImpactStatement
@@ -531,6 +542,7 @@ export type PrototypeFileType =
   | ContaminationReport
   | CouncilTaxBill
   | CrimePreventionStrategy
+  | DecisionNotice
   | DesignAndAccessStatement
   | DisabilityExemptionEvidence
   | EcologyReport


### PR DESCRIPTION
In the DPR we show the application submission and decision notice as a file, theres currently no file type for an application submission or decision notice so we're using otherDocument at the moment. 