### PR TITLE
chore: ensure `PreApplication` has granular fee structure

### DIFF
--- a/examples/preApplication/data/preApp.ts
+++ b/examples/preApplication/data/preApp.ts
@@ -207,7 +207,12 @@ export const preApplication: PreApplication = {
         description: 'Pre-application',
       },
       fee: {
-        payable: 450,
+        calculated: 360,
+        calculatedVAT: 90,
+        serviceCharge: 40,
+        serviceChargeVAT: 8,
+        payable: 498,
+        payableVAT: 98,
         reference: {
           govPay: '8tdudifjrg7va2ud2nptc6iedf',
         },

--- a/examples/preApplication/preApp.json
+++ b/examples/preApplication/preApp.json
@@ -226,7 +226,12 @@
         "description": "Pre-application"
       },
       "fee": {
-        "payable": 450,
+        "calculated": 360,
+        "calculatedVAT": 90,
+        "serviceCharge": 40,
+        "serviceChargeVAT": 8,
+        "payable": 498,
+        "payableVAT": 98,
         "reference": {
           "govPay": "8tdudifjrg7va2ud2nptc6iedf"
         }

--- a/schemas/preApplication.json
+++ b/schemas/preApplication.json
@@ -7047,12 +7047,35 @@
         "fee": {
           "additionalProperties": false,
           "properties": {
+            "calculated": {
+              "description": "Total calculated fee in GBP",
+              "type": "number"
+            },
+            "calculatedVAT": {
+              "type": "number"
+            },
+            "fastTrack": {
+              "description": "Fast Track fee in GBP if applicable",
+              "type": "number"
+            },
+            "fastTrackVAT": {
+              "description": "Fast Track VAT in GBP if applicable",
+              "type": "number"
+            },
             "payable": {
               "description": "Total payable fee after any exemptions or reductions in GBP",
               "type": "number"
             },
             "payableVAT": {
               "description": "Total payable VAT in GBP if applicable",
+              "type": "number"
+            },
+            "paymentProcessing": {
+              "description": "Payment processing fee in GBP if applicable",
+              "type": "number"
+            },
+            "paymentProcessingVAT": {
+              "description": "Payment processing VAT in GBP if applicable",
               "type": "number"
             },
             "reference": {
@@ -7078,9 +7101,18 @@
                 "govPay"
               ],
               "type": "object"
+            },
+            "serviceCharge": {
+              "description": "PlanX service charge fee in GBP if applicable",
+              "type": "number"
+            },
+            "serviceChargeVAT": {
+              "description": "PlanX service charge VAT in GBP if applicable",
+              "type": "number"
             }
           },
           "required": [
+            "calculated",
             "payable"
           ],
           "type": "object"

--- a/types/schemas/preApplication/data/ApplicationData.ts
+++ b/types/schemas/preApplication/data/ApplicationData.ts
@@ -10,7 +10,7 @@ export interface PreApplicationData {
     value: 'preApp';
     description: 'Pre-application';
   };
-  fee: Pick<Fee, 'payable' | 'payableVAT' | 'reference'>;
+  fee: Omit<Fee, 'category' | 'exemption' | 'reduction'>;
   declaration: Declaration;
   information: {
     harmful: {


### PR DESCRIPTION
Pre-apps are VAT-able so we want all possible fields here going forward!